### PR TITLE
fix: sensitive_date validator cleanup and ergonomics

### DIFF
--- a/MODULARIZATION_REPORT.md
+++ b/MODULARIZATION_REPORT.md
@@ -4,20 +4,20 @@
 
 ### Test Modularization Status
 - **Modular test files:** 8 files
-- **Total test lines:** 1,744 lines
-- **Average file size:** 218 lines
+- **Total test lines:** 1,932 lines
+- **Average file size:** 241 lines
 - **Main test file:** 22 lines
 
 ### Test Coverage
-- **Overall coverage:** 98.5%
-- **Total tests:** 332
-- **Statements covered:** 747/758
-- **Files with coverage:** 20
+- **Overall coverage:** 98.7%
+- **Total tests:** 360
+- **Statements covered:** 852/863
+- **Files with coverage:** 21
 
 ### Type Hint Coverage
-- **Files analyzed:** 17
-- **Files with type hints:** 15
-- **Type hint coverage:** 88.2%
+- **Files analyzed:** 18
+- **Files with type hints:** 16
+- **Type hint coverage:** 88.9%
 
 ### Code Quality
 - **Ruff issues:** 0
@@ -29,8 +29,8 @@
 - **Rust vulnerabilities found:** 0
 - **Python security scanning:** ✅ Enabled
 - **Python security issues found:** 0
-- **Files scanned by bandit:** 20
-- **Lines scanned by bandit:** 1,752
+- **Files scanned by bandit:** 21
+- **Lines scanned by bandit:** 2,002
 - **Overall security status:** 🔒 Clean
 - **PyO3 version:** 0.24.1
 
@@ -46,14 +46,14 @@
 ## 🏗️ Test File Organization
 
 ### Modular Test Files
-- **test_validation.py**: 301 lines, 12 functions
-- **test_initialization.py**: 209 lines, 17 functions
-- **test_utility_methods.py**: 74 lines, 4 functions
-- **test_cipher_operations.py**: 163 lines, 9 functions
-- **test_connection_management.py**: 315 lines, 20 functions
-- **test_raw_data_operations.py**: 70 lines, 4 functions
 - **test_certificate_operations.py**: 401 lines, 23 functions
+- **test_validation.py**: 424 lines, 17 functions
 - **test_public_key_operations.py**: 211 lines, 12 functions
+- **test_initialization.py**: 209 lines, 17 functions
+- **test_raw_data_operations.py**: 70 lines, 4 functions
+- **test_utility_methods.py**: 139 lines, 11 functions
+- **test_connection_management.py**: 315 lines, 20 functions
+- **test_cipher_operations.py**: 163 lines, 9 functions
 
 ### Main Test File
 - **test_core.py**: 22 lines, 0 functions
@@ -63,23 +63,24 @@
 ## 🎯 Type Hint Analysis
 
 ### Files with Type Hints
-- **cipher_algorithms.py**: ✅ (145 lines)
-- **core.py**: ✅ (658 lines)
-- **error_handlers.py**: ✅ (29 lines)
 - **config.py**: ❌ (14 lines)
-- **utils/utils.py**: ❌ (1 lines)
+- **core.py**: ✅ (772 lines)
+- **error_handlers.py**: ✅ (29 lines)
+- **cipher_algorithms.py**: ✅ (145 lines)
 - **protocol_handlers/ssl_handler.py**: ✅ (193 lines)
 - **protocol_handlers/ssh_handler.py**: ✅ (77 lines)
 - **protocol_handlers/base.py**: ✅ (28 lines)
+- **utils/utils.py**: ❌ (1 lines)
 - **validators/weak_cipher.py**: ✅ (68 lines)
-- **validators/sensitive_date.py**: ✅ (120 lines)
-- **validators/expiration.py**: ✅ (88 lines)
-- **validators/base.py**: ✅ (55 lines)
+- **validators/sensitive_date.py**: ✅ (204 lines)
+- **validators/subject_alt_names.py**: ✅ (239 lines)
+- **validators/expiration.py**: ✅ (87 lines)
 - **validators/root_certificate_validator.py**: ✅ (113 lines)
 - **validators/tls_version.py**: ✅ (70 lines)
 - **validators/key_info.py**: ✅ (106 lines)
-- **validators/subject_alt_names.py**: ✅ (238 lines)
+- **validators/base.py**: ✅ (141 lines)
 - **validators/hostname.py**: ✅ (148 lines)
+- **validators/_utils.py**: ✅ (23 lines)
 
 ---
 

--- a/certmonitor/validators/_utils.py
+++ b/certmonitor/validators/_utils.py
@@ -1,0 +1,22 @@
+# validators/_utils.py
+
+"""Shared helpers for the built-in validators.
+
+These are package-private (leading underscore) and not part of the public API.
+"""
+
+from datetime import datetime
+from typing import Any, Dict
+
+_NOT_AFTER_FORMAT = "%b %d %H:%M:%S %Y GMT"
+
+
+def parse_not_after(cert: Dict[str, Any]) -> datetime:
+    """Parse the ``notAfter`` field from a validator's ``cert`` argument.
+
+    Centralizes the format string so that any future change to how certmonitor
+    surfaces expiration timestamps only has to be made in one place. Returns a
+    naive ``datetime`` in UTC; callers that need timezone-aware datetimes
+    should attach ``timezone.utc`` themselves (as ``expiration`` does).
+    """
+    return datetime.strptime(cert["cert_info"]["notAfter"], _NOT_AFTER_FORMAT)

--- a/certmonitor/validators/expiration.py
+++ b/certmonitor/validators/expiration.py
@@ -3,6 +3,7 @@
 import datetime
 from typing import Any, Dict
 
+from ._utils import parse_not_after
 from .base import BaseCertValidator
 
 
@@ -58,9 +59,7 @@ class ExpirationValidator(BaseCertValidator):
         """
         # Use timezone.utc for Python 3.8+ compatibility
         now = datetime.datetime.now(datetime.timezone.utc)
-        not_after = datetime.datetime.strptime(
-            cert["cert_info"]["notAfter"], "%b %d %H:%M:%S %Y GMT"
-        ).replace(tzinfo=datetime.timezone.utc)
+        not_after = parse_not_after(cert).replace(tzinfo=datetime.timezone.utc)
 
         is_valid = now < not_after
         days_to_expiry = (not_after - now).days

--- a/certmonitor/validators/sensitive_date.py
+++ b/certmonitor/validators/sensitive_date.py
@@ -4,9 +4,10 @@
 Module for validating SSL certificates against specified sensitive dates.
 """
 
-from datetime import datetime, date
-from typing import Any, Dict, List, NamedTuple, Optional
+from datetime import date, datetime
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
+from ._utils import parse_not_after
 from .base import BaseCertValidator
 
 
@@ -23,10 +24,61 @@ class SensitiveDate(NamedTuple):
     date: date
 
 
+# Any of these forms may appear in the ``dates`` argument of
+# :meth:`SensitiveDateValidator.validate`. They are all normalized internally
+# to a :class:`SensitiveDate`.
+SensitiveDateInput = Union[
+    SensitiveDate,
+    date,
+    str,
+    Tuple[str, date],
+]
+
+
+def _normalize(item: Any) -> SensitiveDate:
+    """Coerce a user-supplied sensitive-date entry to a ``SensitiveDate``.
+
+    Accepted forms:
+      - ``SensitiveDate`` — returned as-is.
+      - ``datetime`` — truncated to its date; name defaults to the ISO date.
+      - ``date`` — wrapped with an ISO-date name.
+      - ``str`` — parsed as ISO 8601 (``YYYY-MM-DD``); name defaults to the string.
+      - ``(name, date)`` tuple — unpacked into a ``SensitiveDate``.
+
+    Raises:
+        TypeError: if ``item`` matches none of the accepted shapes.
+        ValueError: if a string cannot be parsed as an ISO date.
+    """
+    if isinstance(item, SensitiveDate):
+        return item
+    # ``datetime`` is a subclass of ``date``, so check it first.
+    if isinstance(item, datetime):
+        truncated = item.date()
+        return SensitiveDate(name=truncated.isoformat(), date=truncated)
+    if isinstance(item, date):
+        return SensitiveDate(name=item.isoformat(), date=item)
+    if isinstance(item, str):
+        parsed = date.fromisoformat(item)
+        return SensitiveDate(name=item, date=parsed)
+    if isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str):
+        name, value = item
+        if isinstance(value, datetime):
+            value = value.date()
+        if not isinstance(value, date):
+            raise TypeError(
+                f"Second element of (name, date) tuple must be a date, "
+                f"got {type(value).__name__}: {value!r}"
+            )
+        return SensitiveDate(name=name, date=value)
+    raise TypeError(
+        f"Expected SensitiveDate, date, ISO date string, or (name, date) tuple; "
+        f"got {type(item).__name__}: {item!r}"
+    )
+
+
 class SensitiveDateValidator(BaseCertValidator):
     """
     A validator for checking if an SSL certificate expires on a sensitive/special date.
-
 
     Attributes:
         name (str): The name of the validator.
@@ -40,7 +92,7 @@ class SensitiveDateValidator(BaseCertValidator):
         host: str,
         port: int,
         *,
-        dates: Optional[List[SensitiveDate]] = None,
+        dates: Optional[List[SensitiveDateInput]] = None,
     ) -> Dict[str, Any]:
         """
         Validates the sensitivity of the expiry date of the provided SSL certificate.
@@ -49,13 +101,24 @@ class SensitiveDateValidator(BaseCertValidator):
             cert (dict): The SSL certificate.
             host (str): The hostname (not used in this validator).
             port (int): The port number (not used in this validator).
-            dates (list, optional): A list of ``SensitiveDate`` objects to check
-                against the certificate's expiration date. Defaults to ``None``
-                (no sensitive-date matching, only weekend/leap-day checks).
+            dates (list, optional): Sensitive dates to match against the
+                certificate's expiration date. Each entry may be a
+                ``SensitiveDate``, a plain ``date`` / ``datetime``, an ISO date
+                string (``"2025-12-25"``), or a ``(name, date)`` tuple.
+                Defaults to ``None`` (no sensitive-date matching; weekend and
+                leap-day checks still run).
 
         Returns:
-            dict: A dictionary containing the validation results, including whether the certificate
-                expires on a weekend, a leap day, or on any of the passed-in dates.
+            dict: A dictionary containing:
+
+                - ``is_valid`` (bool): ``True`` iff none of the checks fired.
+                - ``leapday_expiry`` (bool): certificate expires on Feb 29.
+                - ``weekend_expiry`` (bool): certificate expires on Saturday/Sunday.
+                - ``sensitive_date_matches`` (list): structured records of any
+                  user-supplied dates that matched, each with ``name`` and
+                  ``date`` (ISO 8601 string).
+                - ``warnings`` (list of str): human-readable summary lines for
+                  every condition that fired.
 
         Examples:
             Example output (success):
@@ -65,6 +128,7 @@ class SensitiveDateValidator(BaseCertValidator):
                     "is_valid": true,
                     "leapday_expiry": false,
                     "weekend_expiry": false,
+                    "sensitive_date_matches": [],
                     "warnings": []
                 }
                 ```
@@ -76,40 +140,64 @@ class SensitiveDateValidator(BaseCertValidator):
                     "is_valid": false,
                     "leapday_expiry": false,
                     "weekend_expiry": true,
+                    "sensitive_date_matches": [
+                        {"name": "Busy Sunday", "date": "2025-11-16"}
+                    ],
                     "warnings": [
-                        'Certificate is due to expire on sensitive date "Busy Sunday" (2025-11-16)'
+                        "Certificate expires on a weekend (Sunday)",
+                        "Certificate is due to expire on sensitive date \\"Busy Sunday\\" (2025-11-16)"
                     ]
                 }
                 ```
         """
-        sensitive_dates: List[SensitiveDate] = list(dates) if dates else []
+        normalized: List[SensitiveDate] = []
+        if dates:
+            for item in dates:
+                try:
+                    normalized.append(_normalize(item))
+                except (TypeError, ValueError) as exc:
+                    return {
+                        "is_valid": False,
+                        "reason": f"Invalid sensitive date input: {exc}",
+                        "leapday_expiry": False,
+                        "weekend_expiry": False,
+                        "sensitive_date_matches": [],
+                        "warnings": [],
+                    }
 
-        for sd in sensitive_dates:
-            if not isinstance(sd, SensitiveDate):
-                raise TypeError(
-                    f"Expected SensitiveDate, got {type(sd).__name__}: {sd!r}"
+        not_after = parse_not_after(cert)
+        expiry_date = not_after.date()
+        weekday = not_after.weekday()
+
+        leapday_expiry = expiry_date.month == 2 and expiry_date.day == 29
+        weekend_expiry = weekday in (5, 6)
+
+        warnings: List[str] = []
+        if leapday_expiry:
+            warnings.append(
+                f"Certificate expires on a leap day ({expiry_date.isoformat()})"
+            )
+        if weekend_expiry:
+            day_name = "Saturday" if weekday == 5 else "Sunday"
+            warnings.append(f"Certificate expires on a weekend ({day_name})")
+
+        sensitive_date_matches: List[Dict[str, str]] = []
+        for sd in normalized:
+            if expiry_date == sd.date:
+                sensitive_date_matches.append(
+                    {"name": sd.name, "date": sd.date.isoformat()}
                 )
-
-        not_after = datetime.strptime(
-            cert["cert_info"]["notAfter"], "%b %d %H:%M:%S %Y GMT"
-        )
-
-        leapday_expiry = not_after.month == 2 and not_after.day == 29
-        weekend_expiry = not_after.weekday() in (5, 6)
-
-        warnings = []
-        for sensitive_date in sensitive_dates:
-            if not_after.date() == sensitive_date.date:
                 warnings.append(
-                    f'Certificate is due to expire on sensitive date "{sensitive_date.name}"'
-                    f" ({sensitive_date.date.isoformat()})"
+                    f'Certificate is due to expire on sensitive date "{sd.name}"'
+                    f" ({sd.date.isoformat()})"
                 )
 
-        is_valid = not (leapday_expiry or warnings or weekend_expiry)
+        is_valid = not (leapday_expiry or weekend_expiry or sensitive_date_matches)
 
         return {
             "is_valid": is_valid,
             "leapday_expiry": leapday_expiry,
             "weekend_expiry": weekend_expiry,
+            "sensitive_date_matches": sensitive_date_matches,
             "warnings": warnings,
         }

--- a/docs/usage/validator_args.md
+++ b/docs/usage/validator_args.md
@@ -36,6 +36,37 @@ results = monitor.validate(
 # }
 ```
 
+## Example: sensitive_date
+
+The `sensitive_date` validator accepts a `dates` list. Each entry may be a
+`SensitiveDate` named tuple, a plain `date`, an ISO 8601 string, or a
+`(name, date)` tuple — whichever fits your config source best.
+
+```python
+from datetime import date
+from certmonitor import CertMonitor
+from certmonitor.validators.sensitive_date import SensitiveDate
+
+with CertMonitor("example.com") as monitor:
+    results = monitor.validate(
+        validator_args={
+            "sensitive_date": {
+                "dates": [
+                    SensitiveDate("Black Friday", date(2025, 11, 28)),
+                    date(2025, 12, 25),           # name defaults to ISO string
+                    "2026-01-01",                 # ISO string; name defaults to itself
+                    ("Go-live", date(2026, 3, 1)),
+                ]
+            }
+        }
+    )
+    print(results["sensitive_date"])
+```
+
+Every matching date is reported both as a structured entry in
+`sensitive_date_matches` (machine-readable) and as a human-readable line in
+`warnings`. Weekend and leap-day expiry also produce warning strings.
+
 ## Discovering what a validator accepts
 
 Use `describe_validators()` to introspect every registered validator and the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - KeyInfo: validators/key_info.md
       - TLSVersion: validators/tls_version.md
       - WeakCipher: validators/weak_cipher.md
+      - SensitiveDate: validators/sensitive_date.md
   - API Reference:
       - CertMonitor: reference/certmonitor.md
       - Validators: reference/validators.md

--- a/tests/test_validators/test_sensitive_date.py
+++ b/tests/test_validators/test_sensitive_date.py
@@ -4,21 +4,24 @@
 Tests for SensitiveDateValidator.
 """
 
-from datetime import date
+from datetime import date, datetime
+
 import pytest
+
 from certmonitor.validators.sensitive_date import SensitiveDate, SensitiveDateValidator
 
 
-def test_leapdayexpiry(sample_cert):
-    """Cert expires on leap day — should flag and be invalid."""
+def test_leapday_expiry_flag_and_warning(sample_cert):
+    """Cert expires on leap day — flag set and warning emitted."""
     sample_cert["notAfter"] = "Feb 29 23:59:59 2028 GMT"
     validator = SensitiveDateValidator()
     result = validator.validate({"cert_info": sample_cert}, "www.example.com", 443)
 
-    assert not result["is_valid"]
-    assert not result["weekend_expiry"]
-    assert result["leapday_expiry"]
-    assert not result["warnings"]
+    assert result["is_valid"] is False
+    assert result["leapday_expiry"] is True
+    assert result["weekend_expiry"] is False
+    assert result["sensitive_date_matches"] == []
+    assert any("leap day" in w for w in result["warnings"])
 
 
 def test_not_leapday_expiry(sample_cert):
@@ -27,157 +30,296 @@ def test_not_leapday_expiry(sample_cert):
     validator = SensitiveDateValidator()
     result = validator.validate({"cert_info": sample_cert}, "www.example.com", 443)
 
-    assert result["is_valid"]
-    assert not result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert not result["warnings"]
+    assert result["is_valid"] is True
+    assert result["weekend_expiry"] is False
+    assert result["leapday_expiry"] is False
+    assert result["warnings"] == []
 
 
-def test_weekend_expiry(sample_cert):
-    """Cert expires on weekend — should flag and be invalid."""
-    sample_cert["notAfter"] = "Mar  4 23:59:59 2028 GMT"
+def test_weekend_expiry_flag_and_warning(sample_cert):
+    """Cert expires on Saturday — flag set and warning emitted with day name."""
+    sample_cert["notAfter"] = "Mar  4 23:59:59 2028 GMT"  # Saturday
     validator = SensitiveDateValidator()
     result = validator.validate({"cert_info": sample_cert}, "www.example.com", 443)
 
-    assert not result["is_valid"]
-    assert result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert not result["warnings"]
+    assert result["is_valid"] is False
+    assert result["weekend_expiry"] is True
+    assert result["leapday_expiry"] is False
+    assert result["sensitive_date_matches"] == []
+    assert any("weekend (Saturday)" in w for w in result["warnings"])
+
+
+def test_sunday_weekend_warning(sample_cert):
+    """Sunday expiry gets a ``Sunday`` warning string."""
+    sample_cert["notAfter"] = "Nov 16 23:59:59 2025 GMT"  # Sunday
+    validator = SensitiveDateValidator()
+    result = validator.validate({"cert_info": sample_cert}, "www.example.com", 443)
+
+    assert result["weekend_expiry"] is True
+    assert any("weekend (Sunday)" in w for w in result["warnings"])
 
 
 def test_not_weekend_expiry(sample_cert):
     """Cert expires on weekday — no flag, should be valid."""
-    sample_cert["notAfter"] = "Mar  1 23:59:59 2028 GMT"
+    sample_cert["notAfter"] = "Mar  1 23:59:59 2028 GMT"  # Wednesday
     validator = SensitiveDateValidator()
     result = validator.validate({"cert_info": sample_cert}, "www.example.com", 443)
 
-    assert result["is_valid"]
-    assert not result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert not result["warnings"]
+    assert result["is_valid"] is True
+    assert result["weekend_expiry"] is False
+    assert result["leapday_expiry"] is False
+    assert result["warnings"] == []
 
 
-def test_sensitive_date_warning_and_invalid(sample_cert):
-    """Cert expires on sensitive date — warning should appear and cert should be invalid."""
+def test_sensitive_date_match_with_sensitive_date_nt(sample_cert):
+    """Matching a SensitiveDate NamedTuple produces a structured match entry."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"  # Monday
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[SensitiveDate("Busy Monday", date(2025, 11, 17))],
+    )
+
+    assert result["is_valid"] is False
+    assert result["weekend_expiry"] is False
+    assert result["leapday_expiry"] is False
+    assert result["sensitive_date_matches"] == [
+        {"name": "Busy Monday", "date": "2025-11-17"}
+    ]
+    assert any('sensitive date "Busy Monday"' in w for w in result["warnings"])
+
+
+def test_sensitive_date_match_with_bare_date(sample_cert):
+    """A bare ``date`` is accepted; name defaults to the ISO string."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[date(2025, 11, 17)],
+    )
+
+    assert result["is_valid"] is False
+    assert result["sensitive_date_matches"] == [
+        {"name": "2025-11-17", "date": "2025-11-17"}
+    ]
+
+
+def test_sensitive_date_match_with_iso_string(sample_cert):
+    """An ISO date string is accepted; name defaults to the string itself."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=["2025-11-17"],
+    )
+
+    assert result["is_valid"] is False
+    assert result["sensitive_date_matches"] == [
+        {"name": "2025-11-17", "date": "2025-11-17"}
+    ]
+
+
+def test_sensitive_date_match_with_name_date_tuple(sample_cert):
+    """A ``(name, date)`` tuple is unpacked into a SensitiveDate."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[("Launch Day", date(2025, 11, 17))],
+    )
+
+    assert result["is_valid"] is False
+    assert result["sensitive_date_matches"] == [
+        {"name": "Launch Day", "date": "2025-11-17"}
+    ]
+
+
+def test_tuple_with_datetime_second_element(sample_cert):
+    """A ``(name, datetime)`` tuple is normalized — datetime is truncated to date."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[("Launch Day", datetime(2025, 11, 17, 9, 0))],
+    )
+
+    assert result["is_valid"] is False
+    assert result["sensitive_date_matches"] == [
+        {"name": "Launch Day", "date": "2025-11-17"}
+    ]
+
+
+def test_sensitive_date_match_with_datetime(sample_cert):
+    """A ``datetime`` is truncated to its date component."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[datetime(2025, 11, 17, 13, 30)],
+    )
+
+    assert result["is_valid"] is False
+    assert result["sensitive_date_matches"] == [
+        {"name": "2025-11-17", "date": "2025-11-17"}
+    ]
+
+
+def test_mixed_input_forms_in_one_call(sample_cert):
+    """All four input forms can be combined in the same ``dates`` list."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[
+            SensitiveDate("NT form", date(2025, 11, 17)),
+            date(2025, 11, 17),
+            "2025-11-17",
+            ("Tuple form", date(2025, 11, 17)),
+        ],
+    )
+
+    assert result["is_valid"] is False
+    assert len(result["sensitive_date_matches"]) == 4
+    names = {m["name"] for m in result["sensitive_date_matches"]}
+    assert names == {"NT form", "2025-11-17", "Tuple form"}
+
+
+def test_sensitive_date_no_match_valid(sample_cert):
+    """Cert expires on a weekday not in the list — valid, no warnings."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"  # Monday
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[SensitiveDate("Busy Tuesday", date(2025, 11, 18))],
+    )
+
+    assert result["is_valid"] is True
+    assert result["sensitive_date_matches"] == []
+    assert result["warnings"] == []
+
+
+def test_multiple_sensitive_date_matches(sample_cert):
+    """Every matching sensitive date shows up in both structured and warning output."""
+    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"  # Monday
+    validator = SensitiveDateValidator()
+    sensitive_dates = [
+        SensitiveDate(f"Day {i + 1}", date(2025, 11, (i % 30) + 1)) for i in range(100)
+    ]
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=sensitive_dates,
+    )
+
+    # Nov 17 is index 16, 46, 76 in the rotating-30 scheme.
+    expected_names = {"Day 17", "Day 47", "Day 77"}
+    assert result["is_valid"] is False
+    assert result["weekend_expiry"] is False
+    assert result["leapday_expiry"] is False
+
+    match_names = {m["name"] for m in result["sensitive_date_matches"]}
+    assert expected_names <= match_names
+    for name in expected_names:
+        assert any(f'"{name}"' in w for w in result["warnings"])
+
+
+def test_invalid_input_type_returns_error_dict(sample_cert):
+    """A non-supported type (e.g. ``int``) returns a structured error, not an exception."""
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[42],  # type: ignore[list-item]
+    )
+
+    assert result["is_valid"] is False
+    assert "Invalid sensitive date input" in result["reason"]
+    assert "int" in result["reason"]
+
+
+def test_invalid_iso_string_returns_error_dict(sample_cert):
+    """A malformed ISO date string returns a structured error."""
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=["not-a-date"],
+    )
+
+    assert result["is_valid"] is False
+    assert "Invalid sensitive date input" in result["reason"]
+
+
+def test_tuple_with_non_date_second_element_returns_error_dict(sample_cert):
+    """A ``(name, not-a-date)`` tuple returns a structured error."""
+    validator = SensitiveDateValidator()
+
+    result = validator.validate(
+        {"cert_info": sample_cert},
+        "www.example.com",
+        443,
+        dates=[("Launch Day", "not a date")],  # type: ignore[list-item]
+    )
+
+    assert result["is_valid"] is False
+    assert "Invalid sensitive date input" in result["reason"]
+
+
+def test_empty_dates_list_still_runs_weekend_leapday_checks(sample_cert):
+    """Passing ``dates=[]`` still runs weekend/leap-day checks."""
     sample_cert["notAfter"] = "Nov 16 23:59:59 2025 GMT"  # Sunday
     validator = SensitiveDateValidator()
-    sensitive_date = SensitiveDate("Busy Sunday", date(2025, 11, 16))
 
     result = validator.validate(
-        {"cert_info": sample_cert},
-        "www.example.com",
-        443,
-        dates=[sensitive_date],
+        {"cert_info": sample_cert}, "www.example.com", 443, dates=[]
     )
 
-    expected_warning = (
-        'Certificate is due to expire on sensitive date "Busy Sunday" (2025-11-16)'
-    )
-
-    assert not result["is_valid"]
-    assert result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert expected_warning in result["warnings"]
+    assert result["is_valid"] is False
+    assert result["weekend_expiry"] is True
+    assert result["sensitive_date_matches"] == []
 
 
-def test_sensitive_date_no_warning_and_valid(sample_cert):
-    """Cert expires on a non-sensitive weekday — no warning, cert should be valid."""
-    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"  # Monday
-    validator = SensitiveDateValidator()
-    sensitive_date = SensitiveDate("Busy Tuesday", date(2025, 11, 18))
-
-    result = validator.validate(
-        {"cert_info": sample_cert},
-        "www.example.com",
-        443,
-        dates=[sensitive_date],
-    )
-
-    assert result["is_valid"]
-    assert not result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert not result["warnings"]
-
-
-def test_many_sensitive_dates_no_match(sample_cert):
-    """Cert expires on a weekday not in the list of sensitive dates — should be valid."""
-    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"  # Monday
-    validator = SensitiveDateValidator()
-    sensitive_dates = []
-
-    # Generate nearly 100 sensitive dates leaving out Nov 17
-    for i in range(100):
-        if (i % 30) + 1 != 17:
-            sensitive_dates.append(
-                SensitiveDate(f"Day {i + 1}", date(2025, 11, (i % 30) + 1))
-            )
-
-    result = validator.validate(
-        {"cert_info": sample_cert},
-        "www.example.com",
-        443,
-        dates=sensitive_dates,
-    )
-
-    assert result["is_valid"]
-    assert not result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert not result["warnings"]
-
-
-def test_many_sensitive_dates_match(sample_cert):
-    """Cert expires on sensitive date — warning should appear and cert should be invalid."""
-    sample_cert["notAfter"] = "Nov 17 23:59:59 2025 GMT"  # Monday
-    validator = SensitiveDateValidator()
-    sensitive_dates = []
-
-    # Generate 100 sensitive dates including Nov 17
-    for i in range(100):
-        sensitive_dates.append(
-            SensitiveDate(f"Day {i + 1}", date(2025, 11, (i % 30) + 1))
-        )
-
-    result = validator.validate(
-        {"cert_info": sample_cert},
-        "www.example.com",
-        443,
-        dates=sensitive_dates,
-    )
-
-    expected_warning_1 = (
-        'Certificate is due to expire on sensitive date "Day 17" (2025-11-17)'
-    )
-    expected_warning_2 = (
-        'Certificate is due to expire on sensitive date "Day 47" (2025-11-17)'
-    )
-    expected_warning_3 = (
-        'Certificate is due to expire on sensitive date "Day 77" (2025-11-17)'
-    )
-
-    assert not result["is_valid"]
-    assert not result["weekend_expiry"]
-    assert not result["leapday_expiry"]
-    assert expected_warning_1 in result["warnings"]
-    assert expected_warning_2 in result["warnings"]
-    assert expected_warning_3 in result["warnings"]
-
-
-def test_sensitive_date_validator_type_check(sample_cert):
-    """Passing non-SensitiveDate args raises TypeError."""
+def test_dates_none_is_equivalent_to_not_provided(sample_cert):
+    """``dates=None`` is equivalent to not passing ``dates`` at all."""
+    sample_cert["notAfter"] = "Mar  1 23:59:59 2028 GMT"  # Wednesday
     validator = SensitiveDateValidator()
 
-    with pytest.raises(TypeError) as excinfo:
-        validator.validate(
-            {"cert_info": sample_cert},
-            "www.example.com",
-            443,
-            dates=[
-                SensitiveDate("Valid SensitiveDate", date(2025, 1, 1)),
-                "A string not a SensitiveDate",  # type: ignore[list-item]
-            ],
-        )
+    result_a = validator.validate({"cert_info": sample_cert}, "www.example.com", 443)
+    result_b = validator.validate(
+        {"cert_info": sample_cert}, "www.example.com", 443, dates=None
+    )
 
-    assert "Expected SensitiveDate, got str" in str(excinfo.value)
+    assert result_a == result_b
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #19 (now merged) addressing the issues that held the `sensitive_date` validator back from the last release. No changes to the core "flag cert expiring on weekend / leap day / user-specified dates" semantics — everything here is additive or ergonomic.

## What changes

### 1. Errors are returned, not raised

`raise TypeError` on malformed input is replaced with a structured error dict, matching every other validator's contract. #19's dispatch layer also catches `TypeError` as a safety net, but the check now lives where it belongs — at the top of `validate()`.

### 2. Input normalization — four accepted forms

The `dates` list now accepts any of:

- `SensitiveDate` (the existing named tuple)
- bare `date` or `datetime` — name auto-generates from the ISO string
- ISO 8601 string (`"2025-12-25"`) — name defaults to the string itself
- `(name, date)` tuple — lightweight alternative to importing `SensitiveDate`

All forms can be mixed freely in one call. Ops teams reading blackout dates from a YAML file can now pass a list of strings; Python users can pass bare `date` objects; the `SensitiveDate` named tuple stays available for callers who want explicit names.

### 3. `sensitive_date_matches` structured field

Every matching date now shows up as a structured entry in a new `sensitive_date_matches: List[{"name": str, "date": str}]` field, in addition to the human-readable line in `warnings`. Callers that previously had to regex-parse warning strings can now read a machine-friendly field. `warnings` is preserved unchanged for log-style output.

### 4. Weekend / leap-day warning strings

When `weekend_expiry=True` or `leapday_expiry=True` fire, a corresponding human-readable line is appended to `warnings`. Previously these conditions set booleans but produced an empty `warnings` list — which looked confusing (`is_valid: false, warnings: []`) when scanning logs. The structured booleans are still there; this just makes log output self-explanatory.

### 5. Shared `parse_not_after` helper

Extracts the `notAfter` `strptime` format string into [certmonitor/validators/_utils.py](certmonitor/validators/_utils.py) and migrates both [expiration.py](certmonitor/validators/expiration.py) and [sensitive_date.py](certmonitor/validators/sensitive_date.py) to use it. Future format changes (e.g. if certmonitor's Rust extension starts returning ISO timestamps) only need to touch one place.

## Docs

- [docs/usage/validator_args.md](docs/usage/validator_args.md) gains a sensitive_date example showing all four input forms.
- [mkdocs.yml](mkdocs.yml) adds the previously-missing `SensitiveDate` nav entry so the validator's auto-generated reference page is reachable. (Pre-existing oversight from #15.)
- [MODULARIZATION_REPORT.md](MODULARIZATION_REPORT.md) regenerated by `make test`.

## Tests

17 new or rewritten tests in [tests/test_validators/test_sensitive_date.py](tests/test_validators/test_sensitive_date.py):

- One test per input form (SensitiveDate, date, datetime, ISO string, (name, date) tuple, (name, datetime) tuple, mixed)
- Weekend warning string content for both Saturday and Sunday
- Leap-day warning string content
- Structured `sensitive_date_matches` field verification
- Structured error dicts for invalid type, malformed ISO string, and bad tuple shape
- `dates=[]` vs `dates=None` equivalence
- 100+ sensitive dates stress test

## Test plan

- [x] `make test` green (360 tests, 98.73% coverage, mypy, bandit, cargo audit, wheel build)
- [x] `sensitive_date.py` at 100% coverage
- [x] `_utils.py` at 100% coverage
- [x] `expiration.py` still at 100% coverage after migration
- [x] No behavior change to weekend / leap-day / user-date matching semantics
- [ ] GitHub Actions CI green

## Out of scope

- Any change to what conditions the validator flags. The conditions (weekend, leap day, exact user-specified date match) are exactly the same as before.