### PR TITLE
feat(validators): key_info recognizes post-quantum algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ rename the headers to emoji form when cutting a release.
 
 ### Added
 - Rust SPKI parser now recognizes post-quantum algorithm OIDs instead of collapsing them to `Unknown`: ML-DSA-44/65/87 (FIPS 204, RFC 9881), all twelve SLH-DSA parameter sets (FIPS 205, RFC 9909), and the eighteen composite ML-DSA signature OIDs from draft-ietf-lamps-pq-composite-sigs-19. `parse_public_key_info` and `analyze_chain` report e.g. `algorithm: "ml-dsa-65"` with `size` set to the subjectPublicKey bit length (PQ strength is judged by algorithm identity, not size). Dict shape is unchanged; existing RSA/EC behavior is regression-tested. Foundation for the upcoming PQ validators (#28, #29).
+- `certinfo.pq_algorithms()` — exposes the Rust post-quantum algorithm registry (`rust_certinfo/src/pq_algorithms.rs`) to Python as `[{"dotted", "name", "composite"}, ...]`, keeping the Rust table the single source of truth for PQ algorithm identity (#28, #30).
 
 ### Changed
-- TBD
+- `key_info` validator now recognizes post-quantum keys: certificates using ML-DSA, SLH-DSA, or composite ML-DSA algorithms return `is_valid: true` instead of the misleading `is_valid: null`. PQ strength is judged by algorithm identity (the registry above); RSA/EC behavior is unchanged and unknown algorithms still return `null` (#30).
 
 ### Fixed
 - TBD

--- a/certmonitor/certinfo.pyi
+++ b/certmonitor/certinfo.pyi
@@ -1,7 +1,7 @@
 # type: ignore
 """Stub file for certinfo Rust module to help with type checking."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 def parse_public_key_info(der_bytes: bytes) -> Dict[str, Any]:
     """Parse public key information from DER bytes."""
@@ -13,4 +13,13 @@ def extract_public_key_der(der_bytes: bytes) -> bytes:
 
 def extract_public_key_pem(der_bytes: bytes) -> str:
     """Extract public key in PEM format."""
+    ...
+
+def analyze_chain(chain_ders: List[bytes]) -> Dict[str, Any]:
+    """Analyze a certificate chain (list of DER certs)."""
+    ...
+
+def pq_algorithms() -> List[Dict[str, Any]]:
+    """Return the post-quantum algorithm registry as
+    [{"dotted": str, "name": str, "composite": bool}, ...]."""
     ...

--- a/certmonitor/validators/key_info.py
+++ b/certmonitor/validators/key_info.py
@@ -1,11 +1,21 @@
 # validators/key_info.py
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, FrozenSet, Optional
+
+from certmonitor import certinfo
 
 from .base import BaseCertValidator
 
+# Post-quantum algorithm names, sourced from the Rust registry
+# (rust_certinfo/src/pq_algorithms.rs) via certinfo.pq_algorithms() so
+# Python never carries its own copy of the table — a new algorithm added
+# there is recognized here automatically.
+_PQ_ALGORITHM_NAMES: FrozenSet[str] = frozenset(
+    alg["name"]
+    for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
+)
 
-# TODO: Implement the KeyInfoValidator - work in progress
+
 class KeyInfoValidator(BaseCertValidator):
     """
     A validator for checking the key information of an SSL certificate.
@@ -92,7 +102,14 @@ class KeyInfoValidator(BaseCertValidator):
 
         Returns:
             bool: True if the key is considered strong enough, False if not.
+            None when the key type is unrecognized or required details are
+            missing.
         """
+        if key_type in _PQ_ALGORITHM_NAMES:
+            # Post-quantum strength is judged by algorithm identity: the
+            # FIPS 204/205 parameter sets and the composite variants have
+            # no weak sizes or curves to check.
+            return True
         if "rsaEncryption" in key_type:
             if key_size is None:
                 return None

--- a/certmonitor/validators/key_info.py
+++ b/certmonitor/validators/key_info.py
@@ -18,7 +18,20 @@ _PQ_ALGORITHM_NAMES: FrozenSet[str] = frozenset(
 
 class KeyInfoValidator(BaseCertValidator):
     """
-    A validator for checking the key information of an SSL certificate.
+    A validator for checking the public key of an SSL certificate.
+
+    Judges key strength per algorithm family:
+
+    - **RSA**: modulus must be at least 2048 bits.
+    - **EC**: curve must be one of secp256r1 / secp384r1 / secp521r1.
+    - **Post-quantum** (ML-DSA, SLH-DSA, and hybrid composite ML-DSA):
+      always strong — PQ strength is judged by algorithm identity, since
+      the FIPS 204/205 parameter sets have no weak sizes or curves. The
+      recognized set comes from the Rust registry exposed via
+      ``certinfo.pq_algorithms()``.
+
+    Unrecognized algorithms return ``is_valid: None`` ("can't judge"),
+    never ``False``.
 
     Attributes:
         name (str): The name of the validator.
@@ -37,7 +50,9 @@ class KeyInfoValidator(BaseCertValidator):
 
         Returns:
             dict: A dictionary containing the validation results, including key type, key size,
-                  whether the key is considered strong enough, and curve information if applicable.
+                  whether the key is considered strong enough (see the class docstring for the
+                  per-family rules, including post-quantum algorithms), and curve information
+                  if applicable.
 
         Examples:
             Example output (success):
@@ -49,6 +64,19 @@ class KeyInfoValidator(BaseCertValidator):
                     "key_size": 2048,
                     "is_valid": true,
                     "curve": null
+                }
+                ```
+
+            Example output (post-quantum key):
+                This example shows a certificate with an ML-DSA-65 (FIPS 204) key. Post-quantum
+                keys are valid by algorithm identity; ``key_size`` reports the subjectPublicKey
+                bit length and is informational only.
+
+                ```json
+                {
+                    "key_type": "ml-dsa-65",
+                    "key_size": 15616,
+                    "is_valid": true
                 }
                 ```
 
@@ -95,10 +123,15 @@ class KeyInfoValidator(BaseCertValidator):
         """
         Checks if the key is strong enough based on its type, size, and curve.
 
+        Post-quantum algorithms (any name in the Rust registry exposed by
+        ``certinfo.pq_algorithms()``) are always strong; RSA requires a
+        modulus of at least 2048 bits; EC requires a strong named curve.
+
         Args:
-            key_type (str): The type of the key.
-            key_size (int): The size of the key.
-            curve (str): The curve of the key (if applicable).
+            key_type (str): The key algorithm name (e.g. ``"rsaEncryption"``,
+                ``"ecPublicKey"``, ``"ml-dsa-65"``).
+            key_size (int): The size of the key. Ignored for PQ algorithms.
+            curve (str): The curve of the key (EC only).
 
         Returns:
             bool: True if the key is considered strong enough, False if not.

--- a/rust_certinfo/src/lib.rs
+++ b/rust_certinfo/src/lib.rs
@@ -79,12 +79,23 @@ mod py {
         Ok(dict.into())
     }
 
+    /// Return the post-quantum algorithm registry as a list of dicts
+    /// `{"dotted": str, "name": str, "composite": bool}`. Python-side
+    /// consumers (e.g. the `key_info` validator) derive their PQ name
+    /// sets from this, so the table in `pq_algorithms.rs` stays the
+    /// single source of truth.
+    #[pyfunction]
+    pub(super) fn pq_algorithms(py: Python<'_>) -> PyResult<Py<PyAny>> {
+        Ok(pyobj::pq_algorithms_list(py)?.into())
+    }
+
     #[pymodule]
     fn certinfo(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(parse_public_key_info, m)?)?;
         m.add_function(wrap_pyfunction!(extract_public_key_der, m)?)?;
         m.add_function(wrap_pyfunction!(extract_public_key_pem, m)?)?;
         m.add_function(wrap_pyfunction!(analyze_chain, m)?)?;
+        m.add_function(wrap_pyfunction!(pq_algorithms, m)?)?;
         Ok(())
     }
 }

--- a/rust_certinfo/src/pyobj.rs
+++ b/rust_certinfo/src/pyobj.rs
@@ -17,6 +17,21 @@ pub fn to_py_err(err: ParseError) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(format!("X.509 parse error: {}", err))
 }
 
+/// Build the list-of-dicts view of the PQ algorithm registry for the
+/// `pq_algorithms` Python function. Each entry is
+/// `{"dotted": str, "name": str, "composite": bool}`.
+pub fn pq_algorithms_list(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
+    let list = PyList::empty(py);
+    for alg in crate::pq_algorithms::PQ_ALGORITHMS {
+        let d = PyDict::new(py);
+        d.set_item("dotted", alg.dotted)?;
+        d.set_item("name", alg.name)?;
+        d.set_item("composite", alg.composite)?;
+        list.append(d)?;
+    }
+    Ok(list)
+}
+
 /// Build the `{"algorithm": ..., "size": ..., "curve": ...}` dict that
 /// `parse_public_key_info` returns. The shape is stable Python-facing
 /// API. For EC keys `curve` carries the curve OID (e.g.

--- a/tests/test_certinfo_pq.py
+++ b/tests/test_certinfo_pq.py
@@ -117,5 +117,25 @@ class TestAnalyzeChainPq:
         assert info == {"algorithm": "unknown", "size": 0, "curve": None}
 
 
+class TestPqAlgorithmsRegistry:
+    """certinfo.pq_algorithms() mirrors the Rust registry."""
+
+    def test_shape_and_count(self):
+        algs = certinfo.pq_algorithms()
+        # 3 ML-DSA + 12 SLH-DSA + 18 composite ML-DSA
+        assert len(algs) == 33
+        for alg in algs:
+            assert set(alg.keys()) == {"dotted", "name", "composite"}
+            assert isinstance(alg["dotted"], str)
+            assert isinstance(alg["name"], str)
+            assert isinstance(alg["composite"], bool)
+
+    def test_known_entries(self):
+        by_name = {alg["name"]: alg for alg in certinfo.pq_algorithms()}
+        assert by_name["ml-dsa-65"]["dotted"] == "2.16.840.1.101.3.4.3.18"
+        assert by_name["ml-dsa-65"]["composite"] is False
+        assert by_name["mldsa44-rsa2048-pss-sha256"]["composite"] is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_validators/test_key_info.py
+++ b/tests/test_validators/test_key_info.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from certmonitor import certinfo
 from certmonitor.validators.key_info import KeyInfoValidator
 
 
@@ -239,6 +240,39 @@ class TestKeyInfoValidator:
         cert_2047 = {"public_key_info": {"algorithm": "rsaEncryption", "size": 2047}}
         result = validator.validate(cert_2047, "example.com", 443)
         assert result["is_valid"] is False
+
+
+class TestKeyInfoPostQuantum:
+    """PQ algorithms are valid by algorithm identity (issue #30).
+
+    Parametrized over the live Rust registry (certinfo.pq_algorithms())
+    so an algorithm added there is covered here with no test changes.
+    """
+
+    @pytest.mark.parametrize(
+        "alg", certinfo.pq_algorithms(), ids=lambda alg: alg["name"]
+    )
+    def test_pq_algorithm_is_valid(self, alg):
+        cert = {"public_key_info": {"algorithm": alg["name"], "size": 15616}}
+        validator = KeyInfoValidator()
+        result = validator.validate(cert, "example.com", 443)
+
+        assert result["key_type"] == alg["name"]
+        assert result["is_valid"] is True
+
+    def test_unknown_pq_like_name_still_returns_none(self):
+        """A PQ-looking name that is not in the registry stays None."""
+        cert = {"public_key_info": {"algorithm": "ml-dsa-99", "size": 1024}}
+        validator = KeyInfoValidator()
+        result = validator.validate(cert, "example.com", 443)
+
+        assert result["is_valid"] is None
+
+    def test_pq_size_is_irrelevant(self):
+        """PQ strength is judged by identity — size 0 must still pass."""
+        validator = KeyInfoValidator()
+        assert validator._is_key_strong_enough("ml-dsa-65", 0, None) is True
+        assert validator._is_key_strong_enough("ml-dsa-65", None, None) is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #30 — Track A, PR 2/7 of the post-quantum validator plan (#28).

## What

`key_info` now recognizes post-quantum keys: certificates using ML-DSA, SLH-DSA, or composite ML-DSA algorithms return `is_valid: true` instead of the misleading `is_valid: null`. PQ strength is judged by **algorithm identity** — the FIPS 204/205 parameter sets have no weak sizes or curves to check.

## How

- **One deliberate addition beyond #30's "no Rust changes" scope:** a new `certinfo.pq_algorithms()` `#[pyfunction]` exposes the Rust registry (`rust_certinfo/src/pq_algorithms.rs`) to Python as `[{"dotted", "name", "composite"}, ...]`. `key_info` derives its PQ name set from it at import, so **Python never carries a duplicate of the algorithm table** — an entry added in Rust is recognized by the validator automatically. This follows #28's architecture decision ("single source of truth for tables: Rust; if Python needs access, expose via a one-line `#[pyfunction]`").
- `_is_key_strong_enough` checks the PQ set first, then falls through to the existing RSA/EC logic unchanged.
- Tests parametrize over the **live registry**, so future algorithms are covered with no test edits; plus the unknown-name edge case (`"ml-dsa-99"` → `null`) and size-irrelevance checks from the issue spec.
- `certinfo.pyi` refreshed (it was missing `analyze_chain`; now also declares `pq_algorithms`).

## Definition of Done (#30)

- [x] One test per PQ algorithm asserting `is_valid: true` (parametrized over the registry — all 33)
- [x] Regression: RSA-2048/4096 valid, RSA-1024/512 invalid, P-256/384/521 valid, weak curve invalid — all unchanged
- [x] Unknown algorithm still returns `is_valid: null`
- [x] CHANGELOG entries (Added: `pq_algorithms()`; Changed: `key_info` behavior)
- [x] Local CI-equivalent green: cargo test (65), clippy `-D warnings`, ruff, mypy, pytest 470 passed @ 98.77% coverage

## Out of scope

`pq_signature` (#31), `pq_chain` (#35), and all Track B work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnpQmB3vEZ5754cETdj7UU)_