### PR TITLE
refactor(core): validator data-source requirements model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ rename the headers to emoji form when cutting a release.
 
 ### Changed
 - `key_info` validator now recognizes post-quantum keys: certificates using ML-DSA, SLH-DSA, or composite ML-DSA algorithms return `is_valid: true` instead of the misleading `is_valid: null`. PQ strength is judged by algorithm identity (the registry above); RSA/EC behavior is unchanged and unknown algorithms still return `null` (#30).
+- Validator dispatcher generalized to a declared data-source model: validators name the data they need via `requires` (e.g. `("cert_data",)`, `("cipher_info", "tls_probe")`); the dispatcher fetches and memoizes each source once per scan and injects them in declaration order. Existing validators are unchanged. A source-fetch failure now produces a uniform structured error result for every dependent validator — fixing a latent bug where a cipher-info fetch error silently dropped cipher validators from the results dict.
 
 ### Fixed
 - TLS probe ClientHello random is now guaranteed to vary between calls. The previous time-plus-stack-address seed could collide when the clock did not advance between two calls (observed on macOS's coarse `SystemTime` resolution), producing identical "random" bytes and a flaky test; a monotonic per-call counter now guarantees distinct values (#33).

--- a/certmonitor/core.py
+++ b/certmonitor/core.py
@@ -577,7 +577,7 @@ class CertMonitor:
             print(results["expiration"])      # Output for expiration validator
             print(results["weak_cipher"])     # Output for weak cipher validator
         """
-        results = {}
+        results: Dict[str, Any] = {}
 
         # Check for unknown validators
         for requested_validator in self.enabled_validators:
@@ -587,56 +587,97 @@ class CertMonitor:
                     "reason": f"Validator '{requested_validator}' is not implemented.",
                 }
 
-        cert_validators = [
+        # Active validators: enabled, implemented, and not already flagged
+        # unknown above. Order follows the registry.
+        active = [
             validator
             for name, validator in self.validators.items()
-            if name in self.enabled_validators
-            and getattr(validator, "validator_type", "cert") == "cert"
-            and name not in results  # exclude already marked unknown validators
+            if name in self.enabled_validators and name not in results
         ]
 
-        cipher_validators = [
-            validator
-            for name, validator in self.validators.items()
-            if name in self.enabled_validators
-            and getattr(validator, "validator_type", "cert") == "cipher"
-            and name not in results
-        ]
+        # Each named data source is fetched at most once per call and
+        # shared across every validator that requires it (e.g. cipher_info
+        # and a future tls_probe).
+        source_cache: Dict[str, Any] = {}
 
-        # Certificate-based validations
-        if cert_validators:
-            cert_data = getattr(self, "cert_data", None)
-            if not cert_data or (isinstance(cert_data, dict) and "error" in cert_data):
-                error_reason = (
-                    cert_data["error"]
-                    if isinstance(cert_data, dict) and "error" in cert_data
-                    else "Certificate data is missing due to a connection or retrieval error."
-                )
-                for validator in cert_validators:
-                    results[validator.name] = {
-                        "is_valid": False,
-                        "reason": f"Certificate-based validation could not be performed: {error_reason}",
-                    }
-            else:
-                for validator in cert_validators:
-                    results[validator.name] = self._invoke_validator(
-                        validator, (cert_data, self.host, self.port), validator_args
-                    )
+        def resolve_source(source_name: str) -> Any:
+            if source_name not in source_cache:
+                source_cache[source_name] = self._fetch_source(source_name)
+            return source_cache[source_name]
 
-        # Cipher-based validations
-        if cipher_validators:
-            cipher_info = self.get_cipher_info()
-            if isinstance(cipher_info, dict) and "error" in cipher_info:
-                logging.error(
-                    "Skipping cipher-based validations due to cipher info retrieval error."
-                )
-            else:
-                for validator in cipher_validators:
-                    results[validator.name] = self._invoke_validator(
-                        validator, (cipher_info, self.host, self.port), validator_args
-                    )
+        for validator in active:
+            # ``requires`` is authoritative when a validator declares it as
+            # a real tuple; otherwise fall back to the legacy
+            # ``validator_type`` mapping (also what test doubles use).
+            requires = getattr(validator, "requires", None)
+            if not isinstance(requires, tuple):
+                vtype = getattr(validator, "validator_type", "cert")
+                requires = ("cipher_info",) if vtype == "cipher" else ("cert_data",)
+
+            resolved: List[Any] = []
+            source_error: Optional[Dict[str, Any]] = None
+            for source_name in requires:
+                value = resolve_source(source_name)
+                source_error = self._source_error(source_name, value)
+                if source_error is not None:
+                    break
+                resolved.append(value)
+
+            # Uniform rule: if any required source could not be obtained,
+            # the validator still appears in the results with a structured
+            # error — never silently omitted.
+            if source_error is not None:
+                results[validator.name] = source_error
+                continue
+
+            results[validator.name] = self._invoke_validator(
+                validator, (*resolved, self.host, self.port), validator_args
+            )
 
         return results
+
+    def _fetch_source(self, source_name: str) -> Any:
+        """Fetch one named data source for the validator dispatcher.
+
+        Sources are intentionally small and registry-like so new ones
+        (e.g. ``tls_probe``) are a single ``elif`` rather than a new
+        dispatch branch. Each may return its normal value or a structured
+        error dict; ``_source_error`` decides which.
+        """
+        if source_name == "cert_data":
+            return getattr(self, "cert_data", None)
+        if source_name == "cipher_info":
+            return self.get_cipher_info()
+        return {
+            "error": "UnknownSource",
+            "message": f"No fetcher registered for data source {source_name!r}.",
+        }
+
+    def _source_error(self, source_name: str, value: Any) -> Optional[Dict[str, Any]]:
+        """Return a structured error result if ``value`` is unusable.
+
+        Returns ``None`` when the source is good. The messages preserve the
+        historical wording so existing callers and tests keep working.
+        """
+        if source_name == "cert_data":
+            if not value or (isinstance(value, dict) and "error" in value):
+                reason = (
+                    value["error"]
+                    if isinstance(value, dict) and "error" in value
+                    else "Certificate data is missing due to a connection or retrieval error."
+                )
+                return {
+                    "is_valid": False,
+                    "reason": f"Certificate-based validation could not be performed: {reason}",
+                }
+            return None
+        if isinstance(value, dict) and "error" in value:
+            label = "Cipher" if source_name == "cipher_info" else source_name
+            return {
+                "is_valid": False,
+                "reason": f"{label}-based validation could not be performed: {value['error']}",
+            }
+        return None
 
     def _invoke_validator(
         self,

--- a/certmonitor/validators/base.py
+++ b/certmonitor/validators/base.py
@@ -16,7 +16,7 @@ discovered user parameters, and exposes them for dispatch and introspection.
 
 import inspect
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, FrozenSet, Mapping
+from typing import Any, ClassVar, Dict, FrozenSet, Mapping, Tuple
 
 
 class BaseValidator(ABC):
@@ -35,13 +35,18 @@ class BaseValidator(ABC):
 class _ValidatorBase(BaseValidator):
     """Internal base that handles user-arg discovery for concrete validators.
 
-    Subclasses set ``_framework_arity`` to the number of positional parameters
-    the dispatcher supplies to ``validate`` (typically 3: the parsed data, the
-    host, and the port). Everything keyword-only after those positional
-    parameters is treated as a user-configurable argument and must be
-    annotated and have a default value.
+    Subclasses declare ``requires`` — an ordered tuple of the named data
+    sources the dispatcher must fetch and inject (e.g. ``("cert_data",)``
+    or ``("cipher_info", "tls_probe")``). The dispatcher supplies those
+    sources as the leading positional parameters of ``validate``, in
+    declaration order, followed by ``host`` and ``port``; the framework
+    arity is therefore ``len(requires) + 2`` and is derived automatically.
+    Everything keyword-only after those positional parameters is treated
+    as a user-configurable argument and must be annotated and defaulted.
     """
 
+    # Ordered data sources the dispatcher injects (see the class docstring).
+    requires: ClassVar[Tuple[str, ...]] = ()
     _framework_arity: ClassVar[int] = 0
     _user_params: ClassVar[Mapping[str, inspect.Parameter]] = {}
     _user_param_names: ClassVar[FrozenSet[str]] = frozenset()
@@ -57,12 +62,15 @@ class _ValidatorBase(BaseValidator):
 
         sig = inspect.signature(cls.validate)
 
-        # Framework params are the first ``_framework_arity`` non-``self``
-        # positional parameters, regardless of what they are named.
+        # Framework params are the leading positional parameters — one per
+        # declared data source, plus host and port — regardless of name.
+        # Derive the arity from ``requires`` so a validator only declares
+        # its sources, never a separate count.
+        arity = len(cls.requires) + 2
+        cls._framework_arity = arity
         user_params: Dict[str, inspect.Parameter] = {}
         problems = []
         positional_seen = 0
-        arity = cls._framework_arity
 
         for param_name, param in sig.parameters.items():
             if param_name == "self":
@@ -118,7 +126,7 @@ class BaseCertValidator(_ValidatorBase):
     """Base class for validators that inspect parsed certificate data."""
 
     validator_type: str = "cert"
-    _framework_arity: ClassVar[int] = 3
+    requires: ClassVar[Tuple[str, ...]] = ("cert_data",)
 
     def validate(
         self, cert_info: Dict[str, Any], host: str, port: int
@@ -131,7 +139,7 @@ class BaseCipherValidator(_ValidatorBase):
     """Base class for validators that inspect negotiated cipher suite data."""
 
     validator_type: str = "cipher"
-    _framework_arity: ClassVar[int] = 3
+    requires: ClassVar[Tuple[str, ...]] = ("cipher_info",)
 
     def validate(
         self, cipher_info: Dict[str, Any], host: str, port: int

--- a/tests/test_core/test_validation.py
+++ b/tests/test_core/test_validation.py
@@ -331,7 +331,8 @@ class TestCipherValidators:
                 )
 
     def test_validate_cipher_validators_cipher_error(self):
-        """Test validate() handles cipher info errors for cipher validators."""
+        """A cipher-info fetch error yields a structured result for the
+        validator (not a silent omission) — uniform with the cert path."""
         monitor = CertMonitor("www.example.com")
         monitor.enabled_validators = ["weak_cipher"]
 
@@ -349,8 +350,13 @@ class TestCipherValidators:
             with patch.object(monitor, "get_cipher_info", return_value=cipher_error):
                 result = monitor.validate()
 
-                # Cipher validators should be skipped when cipher info has errors
-                assert "weak_cipher" not in result or len(result) == 0
+                # Present with a structured error — never dropped from the
+                # results dict (regression: monitoring pipelines that index
+                # results["weak_cipher"] must not KeyError).
+                assert "weak_cipher" in result
+                assert result["weak_cipher"]["is_valid"] is False
+                assert "ConnectionError" in result["weak_cipher"]["reason"]
+                mock_validator.validate.assert_not_called()
 
     def test_validate_cipher_validators_with_args(self):
         """Cipher validators receive args as kwargs from the canonical dict form."""
@@ -381,6 +387,89 @@ class TestCipherValidators:
                     monitor.port,
                     min_strength=256,
                 )
+
+
+class TestRequiresModel:
+    """The dispatcher resolves declared data sources, memoizes them per
+    call, and fails uniformly when a source is unavailable."""
+
+    def test_multi_source_validator_receives_sources_in_order(self):
+        """A validator declaring requires=(cipher_info, tls_probe) gets both
+        injected, in order, before host/port."""
+        monitor = CertMonitor("www.example.com")
+        monitor.enabled_validators = ["multi"]
+
+        mock_validator = MagicMock()
+        mock_validator.name = "multi"
+        mock_validator.requires = ("cipher_info", "tls_probe")
+        mock_validator._user_param_names = frozenset()
+        mock_validator.validate.return_value = {"is_valid": True}
+
+        cipher_info = {"protocol_version": "TLSv1.3"}
+        probe = {"result": "group", "is_pq": True}
+
+        with patch.object(monitor, "validators", {"multi": mock_validator}):
+            with patch.object(monitor, "get_cipher_info", return_value=cipher_info):
+                with patch.object(
+                    monitor, "_fetch_source", wraps=monitor._fetch_source
+                ) as fetch:
+                    # Route tls_probe through the cache without a real socket.
+                    def fake_fetch(name):
+                        if name == "tls_probe":
+                            return probe
+                        return monitor.get_cipher_info()
+
+                    fetch.side_effect = fake_fetch
+                    result = monitor.validate()
+
+        assert result["multi"]["is_valid"] is True
+        mock_validator.validate.assert_called_once_with(
+            cipher_info, probe, monitor.host, monitor.port
+        )
+
+    def test_source_fetched_once_and_shared(self):
+        """Two validators requiring the same source trigger a single fetch."""
+        monitor = CertMonitor("www.example.com")
+        monitor.enabled_validators = ["a", "b"]
+
+        def make(name):
+            v = MagicMock()
+            v.name = name
+            v.validator_type = "cipher"
+            v._user_param_names = frozenset()
+            v.validate.return_value = {"is_valid": True}
+            return v
+
+        cipher_info = {"protocol_version": "TLSv1.3"}
+        with patch.object(monitor, "validators", {"a": make("a"), "b": make("b")}):
+            with patch.object(
+                monitor, "get_cipher_info", return_value=cipher_info
+            ) as gci:
+                result = monitor.validate()
+
+        assert result["a"]["is_valid"] is True
+        assert result["b"]["is_valid"] is True
+        gci.assert_called_once()  # memoized across both validators
+
+    def test_multi_source_validator_source_failure_is_structured(self):
+        """If one required source errors, the validator gets a structured
+        error and is not called."""
+        monitor = CertMonitor("www.example.com")
+        monitor.enabled_validators = ["multi"]
+
+        mock_validator = MagicMock()
+        mock_validator.name = "multi"
+        mock_validator.requires = ("cipher_info", "tls_probe")
+        mock_validator._user_param_names = frozenset()
+
+        cipher_error = {"error": "ConnectionError", "message": "no cipher"}
+        with patch.object(monitor, "validators", {"multi": mock_validator}):
+            with patch.object(monitor, "get_cipher_info", return_value=cipher_error):
+                result = monitor.validate()
+
+        assert result["multi"]["is_valid"] is False
+        assert "ConnectionError" in result["multi"]["reason"]
+        mock_validator.validate.assert_not_called()
 
 
 class TestMixedValidators:


### PR DESCRIPTION
Foundation for #34 (the `pq_key_exchange` validator), split out as a pure-infrastructure refactor so it reviews in isolation. Part of the PQ plan (#28); this is the "small dispatcher data-source refactor" step that precedes #34.

## Why

`pq_key_exchange` is the first validator that needs **two** inputs — the negotiated TLS version (`cipher_info`, for the skip-legacy short-circuit) *and* the probe result (`tls_probe`). The old dispatcher had exactly two hardcoded branches (cert → `cert_data`, cipher → `cipher_info`), with no way to express "needs both" short of a validator doing its own network I/O inside `validate()`. This generalizes the dispatch so new data sources are declarative, not new branches.

## What changes

- **Validators declare an ordered `requires` tuple** of named data sources. `BaseCertValidator` → `("cert_data",)`, `BaseCipherValidator` → `("cipher_info",)` (one-line shims). The dispatcher resolves each source, **memoizes it once per `validate()` call**, and injects the resolved values as the leading positional args of `validate()` before `host`/`port`. Framework arity is derived as `len(requires) + 2`, so a validator only declares its sources — never a separate count.
- **Existing validators and test doubles are untouched.** `requires` is authoritative only when it's a real tuple; otherwise the dispatcher falls back to the legacy `validator_type` mapping (which is also what the `MagicMock`-based tests set). Every existing validator keeps its `validate(self, data, host, port)` signature.
- **Bug fix (was silent):** a `cipher_info` fetch error previously dropped cipher validators from the results dict entirely — a monitoring pipeline doing `results["weak_cipher"]` would `KeyError`. Source failures now produce a **uniform structured error result** for every dependent validator, exactly matching the long-standing cert-path behavior. The one test that pinned the old omission is updated to assert the new (correct) behavior.

New source fetchers live in `_fetch_source` / `_source_error`; adding `tls_probe` in #34 is one branch in each. Existing cert/cipher error messages are preserved verbatim.

## Tests

- All existing dispatch tests pass unchanged (the `requires`-as-tuple guard preserves the `validator_type` path for mocks).
- New `TestRequiresModel`: multi-source injection in declared order, single fetch shared across validators (memoization), and structured error when one required source fails.
- Updated `test_validate_cipher_validators_cipher_error` to assert the validator now appears with a structured error rather than being omitted.
- Gate: **473 passed, 98.70% coverage**, ruff + mypy clean; Rust untouched.

> Note: depends on #42 (TLS probe random fix) — until that merges, this branch's macOS Rust job fails on the pre-existing `develop` bug. I'll rebase onto develop after #42 lands.

## DoD

- [x] No behavior change for existing validators (signatures, messages, results)
- [x] Silent cipher-omission bug fixed, with regression test
- [x] `make ci`-equivalent green locally
- [x] CHANGELOG entry added