### PR TITLE
fix(rust): TLS probe ClientHello random can collide between calls (macOS flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ rename the headers to emoji form when cutting a release.
 - `key_info` validator now recognizes post-quantum keys: certificates using ML-DSA, SLH-DSA, or composite ML-DSA algorithms return `is_valid: true` instead of the misleading `is_valid: null`. PQ strength is judged by algorithm identity (the registry above); RSA/EC behavior is unchanged and unknown algorithms still return `null` (#30).
 
 ### Fixed
-- TBD
+- TLS probe ClientHello random is now guaranteed to vary between calls. The previous time-plus-stack-address seed could collide when the clock did not advance between two calls (observed on macOS's coarse `SystemTime` resolution), producing identical "random" bytes and a flaky test; a monotonic per-call counter now guarantees distinct values (#33).
 
 ## [0.3.0] - 2026-04-15
 

--- a/rust_certinfo/src/tls/probe.rs
+++ b/rust_certinfo/src/tls/probe.rs
@@ -20,6 +20,7 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
 use crate::tls::handshake::{
@@ -63,18 +64,28 @@ pub enum ProbeResult {
     Error { kind: String, message: String },
 }
 
+/// Monotonic per-call counter. Mixed into `client_random` so two calls
+/// can never produce identical output even when the clock does not
+/// advance between them (e.g. macOS's coarse `SystemTime` resolution,
+/// which made a time-only seed collide and flake the unit test).
+static RANDOM_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 /// Fill 32 bytes of ClientHello random without a CSPRNG dependency.
 /// A fixed value would make every probe trivially fingerprintable
-/// (the WAF-evasion concern in #28); this is per-call varying, which
-/// is all that's needed — the bytes are never used cryptographically.
+/// (the WAF-evasion concern in #28); this only needs to vary per call,
+/// which the counter guarantees — the bytes are never used
+/// cryptographically.
 fn client_random() -> [u8; 32] {
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)
         .unwrap_or(0);
-    // Mix the clock with the stack address of a local for extra
-    // per-call variation, then expand with splitmix64.
-    let mut state = nanos ^ (&nanos as *const u64 as u64);
+    // A strictly-increasing counter (times an odd constant, a bijection
+    // mod 2^64) guarantees distinct seeds across calls; the clock and a
+    // stack address add cross-run variation. Expanded with splitmix64.
+    let counter = RANDOM_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut state =
+        nanos ^ (&nanos as *const u64 as u64) ^ counter.wrapping_mul(0x9E37_79B9_7F4A_7C15);
     let mut out = [0u8; 32];
     for chunk in out.chunks_mut(8) {
         state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
@@ -325,7 +336,12 @@ mod tests {
 
     #[test]
     fn client_random_varies_between_calls() {
-        assert_ne!(client_random(), client_random());
+        // The monotonic counter guarantees distinctness even when the
+        // clock does not advance between calls; assert it over many
+        // consecutive calls, not just two.
+        use std::collections::HashSet;
+        let seen: HashSet<[u8; 32]> = (0..256).map(|_| client_random()).collect();
+        assert_eq!(seen.len(), 256, "client_random produced a collision");
     }
 
     #[test]


### PR DESCRIPTION
Fixes a real bug in the TLS probe from #33, surfaced by PR #41's macOS Rust job ([failing run](https://github.com/bradh11/certmonitor/actions/runs/27278757069/job/80567192531)).

## The bug

`client_random()` (the ClientHello `random`) seeded only from `SystemTime::now()` nanos XOR'd with a stack address. On macOS's coarse `SystemTime` resolution, two back-to-back calls can read **identical nanos** and reuse the **same stack slot**, so both entropy sources collide and the function returns identical bytes.

This is a genuine defect, not an over-strict test: the probe's `random` exists to keep probes from being byte-identical (the anti-fingerprint goal in #28). The unit test `client_random_varies_between_calls` correctly caught it — it passed on the Linux runners by luck (the nanosecond clock happened to advance) and failed on macOS.

It's on `develop` already (merged with #33/#40); it surfaced on #41 because every branch runs the full Rust suite.

## The fix

Mix a process-wide monotonic `AtomicU64` counter (times an odd constant — a bijection mod 2^64) into the splitmix64 seed. Distinct calls now always get distinct seeds regardless of clock resolution, so output can never collide; the clock + stack address still add cross-run variation. No new dependency, still no CSPRNG.

Test strengthened to assert **256 consecutive calls are all unique**, not just two.

## Verification

- `cargo test`, `cargo clippy -D warnings`, `cargo fmt` clean locally; full CI matrix green including the macOS Rust job.

Once merged, the in-flight PR #41 (and the upcoming pq_key_exchange PR) rebase onto develop and pick this up.