### PR TITLE
feat(validators): formalize the standard result envelope

### DIFF
--- a/certmonitor/validators/__init__.py
+++ b/certmonitor/validators/__init__.py
@@ -1,6 +1,8 @@
 # validators/__init__.py
 from typing import Any
 
+from .results import ValidationResult as ValidationResult
+
 from .chain import ChainValidator
 from .expiration import ExpirationValidator
 from .hostname import HostnameValidator

--- a/certmonitor/validators/base.py
+++ b/certmonitor/validators/base.py
@@ -28,8 +28,15 @@ class BaseValidator(ABC):
         """Return the name used to register and look up this validator."""
 
     @abstractmethod
-    def validate(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
-        """Run the validator and return a result dict."""
+    def validate(self, *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+        """Run the validator and return a result dict.
+
+        The result must conform to the standard envelope — see
+        :class:`certmonitor.validators.results.ValidationResult`. The
+        return type is ``Mapping`` (not ``Dict``) so overrides may
+        annotate a precise ``TypedDict``; at runtime every result is a
+        plain dict.
+        """
 
 
 class _ValidatorBase(BaseValidator):
@@ -130,7 +137,7 @@ class BaseCertValidator(_ValidatorBase):
 
     def validate(
         self, cert_info: Dict[str, Any], host: str, port: int
-    ) -> Dict[str, Any]:
+    ) -> Mapping[str, Any]:
         # Default implementation — subclasses override.
         return None  # type: ignore[return-value]
 
@@ -143,6 +150,6 @@ class BaseCipherValidator(_ValidatorBase):
 
     def validate(
         self, cipher_info: Dict[str, Any], host: str, port: int
-    ) -> Dict[str, Any]:
+    ) -> Mapping[str, Any]:
         # Default implementation — subclasses override.
         return None  # type: ignore[return-value]

--- a/certmonitor/validators/pq_chain.py
+++ b/certmonitor/validators/pq_chain.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Dict, FrozenSet, List, Optional
 from certmonitor import certinfo
 
 from .base import BaseCertValidator
+from .results import ValidationResult
 
 # Post-quantum algorithm identities, sourced from the Rust registry
 # (rust_certinfo/src/pq_algorithms.rs) so Python never carries its own
@@ -18,6 +19,14 @@ _PQ_SIG_OIDS: FrozenSet[str] = frozenset(
     alg["dotted"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
 )
+
+
+class PqChainResult(ValidationResult, total=False):
+    """Result shape for :class:`PqChainValidator` (envelope + data)."""
+
+    chain_length: int
+    certs: List[Dict[str, Any]]
+    summary: Dict[str, Optional[bool]]
 
 
 class PqChainValidator(BaseCertValidator):
@@ -63,7 +72,7 @@ class PqChainValidator(BaseCertValidator):
         port: int,
         *,
         require_full_chain: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> PqChainResult:
         """Walk the presented chain and report per-certificate PQ posture.
 
         Args:
@@ -156,7 +165,7 @@ class PqChainValidator(BaseCertValidator):
         else:
             is_valid = bool(summary["leaf_pq"])
 
-        result: Dict[str, Any] = {
+        result: PqChainResult = {
             "chain_length": len(certs),
             "certs": certs,
             "summary": summary,
@@ -179,7 +188,7 @@ class PqChainValidator(BaseCertValidator):
         return all(entry["is_pq"] for entry in of_role)
 
     @staticmethod
-    def _error_result(reason: str) -> Dict[str, Any]:
+    def _error_result(reason: str) -> PqChainResult:
         return {
             "is_valid": False,
             "reason": reason,

--- a/certmonitor/validators/pq_key_exchange.py
+++ b/certmonitor/validators/pq_key_exchange.py
@@ -1,8 +1,19 @@
 # validators/pq_key_exchange.py
 
-from typing import Any, ClassVar, Dict, Tuple
+from typing import Any, ClassVar, Dict, Optional, Tuple
 
 from .base import BaseCipherValidator
+from .results import ValidationResult
+
+
+class PqKeyExchangeResult(ValidationResult, total=False):
+    """Result shape for :class:`PqKeyExchangeValidator` (envelope + data)."""
+
+    kem_id: Optional[int]
+    kem_name: str
+    kem_kind: str
+    is_pq: bool
+    via_hello_retry_request: bool
 
 
 class PqKeyExchangeValidator(BaseCipherValidator):
@@ -26,7 +37,7 @@ class PqKeyExchangeValidator(BaseCipherValidator):
     | TLS 1.3 + hybrid/pure PQ group | ``is_valid: True`` |
     | TLS 1.3 + classical group | ``is_valid: False`` — classical KEX, HNDL-exposed |
     | TLS 1.2 or older | ``is_valid: False`` — no PQ KEMs defined (probe skipped) |
-    | Connection/probe error | ``{error, message, is_valid: False}`` |
+    | Connection/probe error | ``{error, message, reason, is_valid: False}`` |
 
     The skip-for-legacy short-circuit (no second TCP connection for
     TLS < 1.3) lives in the ``tls_probe`` data source, so by the time this
@@ -49,7 +60,7 @@ class PqKeyExchangeValidator(BaseCipherValidator):
         tls_probe: Dict[str, Any],
         host: str,
         port: int,
-    ) -> Dict[str, Any]:
+    ) -> PqKeyExchangeResult:
         """Classify the negotiated key exchange.
 
         Args:
@@ -61,7 +72,8 @@ class PqKeyExchangeValidator(BaseCipherValidator):
         Returns:
             dict: ``{kem_id, kem_name, kem_kind, is_pq, is_valid}`` on a
             negotiated group; an ``n/a`` result for TLS < 1.3; or a
-            ``{error, message, is_valid}`` dict on a probe/connection error.
+            ``{error, message, reason, is_valid}`` dict on a
+            probe/connection error.
 
         Examples:
             Hybrid PQ key exchange (success):
@@ -90,11 +102,15 @@ class PqKeyExchangeValidator(BaseCipherValidator):
         result = tls_probe.get("result")
 
         if result == "error":
-            # Connection/probe failure — surface the standard error shape.
+            # Connection/probe failure — an operational failure is still a
+            # result: reason satisfies the envelope, error/message keep the
+            # machine-readable class.
+            message = tls_probe.get("message", "TLS probe failed")
             return {
                 "error": tls_probe.get("error", "ProbeError"),
-                "message": tls_probe.get("message", "TLS probe failed"),
+                "message": message,
                 "is_valid": False,
+                "reason": message,
             }
 
         if result == "n/a":
@@ -115,7 +131,7 @@ class PqKeyExchangeValidator(BaseCipherValidator):
         if result == "group":
             is_pq = bool(tls_probe.get("is_pq", False))
             name = tls_probe.get("name", "unknown")
-            out: Dict[str, Any] = {
+            out: PqKeyExchangeResult = {
                 "kem_id": tls_probe.get("id"),
                 "kem_name": name,
                 "kem_kind": tls_probe.get("kind", "unknown"),

--- a/certmonitor/validators/pq_signature.py
+++ b/certmonitor/validators/pq_signature.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Dict, FrozenSet, Optional
 from certmonitor import certinfo
 
 from .base import BaseCertValidator
+from .results import ValidationResult
 
 # Post-quantum algorithm identities, sourced from the Rust registry
 # (rust_certinfo/src/pq_algorithms.rs) so Python never carries its own
@@ -29,6 +30,17 @@ _COMPOSITE_SIG_OIDS: FrozenSet[str] = frozenset(
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
     if alg["composite"]
 )
+
+
+class PqSignatureResult(ValidationResult, total=False):
+    """Result shape for :class:`PqSignatureValidator` (envelope + data)."""
+
+    key_algorithm: str
+    key_is_pq: bool
+    signature_algorithm_oid: str
+    signature_is_pq: bool
+    is_hybrid_composite: bool
+    is_pq: bool
 
 
 class PqSignatureValidator(BaseCertValidator):
@@ -68,7 +80,7 @@ class PqSignatureValidator(BaseCertValidator):
         port: int,
         *,
         require_pq_signature: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> PqSignatureResult:
         """Judge the leaf certificate's post-quantum posture.
 
         Args:
@@ -138,7 +150,7 @@ class PqSignatureValidator(BaseCertValidator):
 
         is_valid = key_is_pq and (signature_is_pq or not require_pq_signature)
 
-        result: Dict[str, Any] = {
+        result: PqSignatureResult = {
             "key_algorithm": key_algorithm,
             "key_is_pq": key_is_pq,
             "signature_algorithm_oid": sig_oid,

--- a/certmonitor/validators/results.py
+++ b/certmonitor/validators/results.py
@@ -1,0 +1,69 @@
+# validators/results.py
+
+"""The standard validator result envelope.
+
+Every validator returns a plain dict (JSON-serializable, accessed with
+``result["is_valid"]``). These :class:`~typing.TypedDict` classes declare
+the *schema* of that dict without changing its runtime type, so mypy can
+enforce the contract while consumers keep working with ordinary dicts.
+
+The envelope contract:
+
+==============  =================  ====================================
+Key             Type               Rule
+==============  =================  ====================================
+``is_valid``    ``bool``           Always present, strict bool — never
+                                   ``None`` in conforming validators.
+``reason``      ``str``            Present **iff** ``is_valid`` is
+                                   ``False``. One human-readable sentence
+                                   stating the primary cause.
+``warnings``    ``List[str]``      Optional. Non-fatal findings.
+``error``       ``str``            Optional. Machine-readable error class
+                                   on operational failures (connection
+                                   refused, probe failed, …).
+``message``     ``str``            Optional. Human-readable detail
+                                   accompanying ``error``.
+==============  =================  ====================================
+
+All other keys are validator-specific **data** fields: snake_case,
+documented on the validator's docs page, and stable across releases. The
+five reserved keys above are never reused for data.
+
+Operational failures are still results: a validator whose data source
+cannot be fetched reports ``is_valid: False`` with a ``reason`` (plus
+``error``/``message`` where a machine-readable class helps) — it is never
+silently omitted from ``validate()`` output.
+
+A validator declares its full shape by extending :class:`ValidationResult`
+with its data fields (see ``pq_signature.py`` for an example)::
+
+    class MyResult(ValidationResult, total=False):
+        my_data_field: str
+
+Note:
+    ``typing.NotRequired`` does not exist on Python 3.8 and the project
+    has a zero-dependency rule (no ``typing_extensions``), hence the
+    two-class required/optional split below.
+"""
+
+from typing import List, TypedDict
+
+
+class _ValidationResultBase(TypedDict):
+    """The required envelope keys — every validator result carries these."""
+
+    is_valid: bool
+
+
+class ValidationResult(_ValidationResultBase, total=False):
+    """Standard validator result envelope (see module docstring).
+
+    ``is_valid`` is required; the four optional keys below are reserved
+    and may only carry envelope semantics. Validator-specific data fields
+    are declared by extending this class with ``total=False``.
+    """
+
+    reason: str
+    warnings: List[str]
+    error: str
+    message: str

--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -1,3 +1,7 @@
 # API Reference: Validators
 
 ::: certmonitor.validators
+
+## The result envelope
+
+::: certmonitor.validators.results

--- a/docs/usage/custom_validators.md
+++ b/docs/usage/custom_validators.md
@@ -13,30 +13,47 @@ Some use cases for custom validators include:
 
 ## How to Create a Custom Validator
 
-1. **Subclass the base validator** (usually `BaseCertValidator` for certificate-based, or create your own for cipher-based):
-2. **Implement the `validate` method** with your custom logic.
-3. **Register your validator** by adding it to the `VALIDATORS` dictionary (or pass it to CertMonitor).
+1. **Subclass the base validator** (`BaseCertValidator` for certificate-based, `BaseCipherValidator` for cipher-based).
+2. **Implement the `validate` method** with your custom logic. User-configurable arguments must be declared as **keyword-only** parameters (after `*`), each with a type annotation and a default — this is enforced at import time.
+3. **Return a result that follows the [result contract](../validators/index.md#the-result-contract)**: `is_valid` is always a strict bool, and `reason` is present exactly when `is_valid` is `False`.
+4. **Register your validator** with `register_validator()`.
 
 ### Example: Enforce a Minimum Key Size
 
 Suppose you want to ensure all certificates use at least a 3072-bit RSA key.
 
 ```python
+from typing import Any, Dict, Optional
+
 from certmonitor.validators.base import BaseCertValidator
+from certmonitor.validators.results import ValidationResult
+
+
+class MinKeySizeResult(ValidationResult, total=False):
+    """Declares the result shape so mypy checks it (optional but recommended)."""
+
+    key_size: Optional[int]
+    min_size: int
+
 
 class MinKeySizeValidator(BaseCertValidator):
     name = "min_key_size"
 
-    def validate(self, cert, host, port, min_size=3072):
-        key_info = cert.get("public_key_info", {})
-        key_size = key_info.get("size")
+    def validate(
+        self, cert: Dict[str, Any], host: str, port: int, *, min_size: int = 3072
+    ) -> MinKeySizeResult:
+        key_size = cert.get("public_key_info", {}).get("size")
         is_valid = key_size is not None and key_size >= min_size
-        return {
+        result: MinKeySizeResult = {
             "is_valid": is_valid,
             "key_size": key_size,
             "min_size": min_size,
-            "reason": f"Key size {key_size} is {'acceptable' if is_valid else 'too small'} (minimum required: {min_size})"
         }
+        if not is_valid:
+            result["reason"] = (
+                f"Key size {key_size} is too small (minimum required: {min_size})"
+            )
+        return result
 ```
 
 ### Register and Use Your Validator
@@ -52,7 +69,8 @@ register_validator(MinKeySizeValidator())
 
 # Enable your validator by name and pass arguments if needed
 with CertMonitor("example.com", enabled_validators=["min_key_size"]) as monitor:
-    results = monitor.validate({"min_key_size": [4096]})  # Require at least 4096 bits
+    # Arguments are passed as a dict of keyword arguments per validator
+    results = monitor.validate({"min_key_size": {"min_size": 4096}})
     print(results["min_key_size"])
 ```
 

--- a/docs/validators/index.md
+++ b/docs/validators/index.md
@@ -13,8 +13,47 @@ Available validators:
 - [WeakCipher](weak_cipher.md): Validates that the negotiated cipher suite is in the allowed list.
 - [SensitiveDate](sensitive_date.md): Validates that the certificate doesn't expire on built-in or user specified sensitive dates.
 - [Chain](chain.md): Inspects the full TLS certificate chain for structural problems (missing intermediates, out-of-order, expired members). Opt-in; requires Python 3.10+.
+- [PqKeyExchange](pq_key_exchange.md): Judges whether the negotiated TLS key exchange is post-quantum (hybrid or pure ML-KEM). Opt-in.
+- [PqChain](pq_chain.md): Reports the post-quantum posture of every certificate in the presented chain. Opt-in; requires Python 3.10+.
+- [PqSignature](pq_signature.md): Judges the leaf certificate's post-quantum posture (key and signature algorithm). Opt-in.
 
 See each page for usage and output examples.
+
+## The result contract
+
+Every validator returns a plain, JSON-serializable dict. Results from the
+post-quantum validators conform to a standard envelope, declared as a
+`TypedDict` in `certmonitor.validators.results.ValidationResult` so mypy can
+enforce it without changing the runtime type:
+
+| Key | Type | Rule |
+|---|---|---|
+| `is_valid` | `bool` | Always present, strict bool — never `None`. |
+| `reason` | `str` | Present **iff** `is_valid` is `False`. One human-readable sentence stating the primary cause. |
+| `warnings` | `List[str]` | Optional. Non-fatal findings. |
+| `error` | `str` | Optional. Machine-readable error class on operational failures. |
+| `message` | `str` | Optional. Human-readable detail accompanying `error`. |
+
+All other keys are validator-specific **data** fields: snake_case, documented
+on the validator's page, and stable across releases. The five reserved keys
+above are never reused for data.
+
+Two corollaries:
+
+1. **Operational failures are still results.** A validator whose data source
+   cannot be fetched (connection error, probe failure, chain missing) still
+   appears in `validate()` output with `is_valid: False` and a `reason` — it
+   is never silently omitted, so `results["<name>"]` never raises `KeyError`
+   in a monitoring pipeline.
+2. **Schema is static-only.** A custom validator declares its full shape by
+   extending `ValidationResult` with its data fields (see
+   `pq_signature.py` for an example); the value your code receives is still
+   an ordinary dict.
+
+The pre-existing validators (`expiration`, `key_info`, …) predate this
+contract and keep their legacy shapes for now — notably `key_info` may
+return `is_valid: None` for unknown key types. They will migrate behind a
+deprecation cycle.
 
 ---
 

--- a/tests/test_validators/test_pq_key_exchange.py
+++ b/tests/test_validators/test_pq_key_exchange.py
@@ -106,6 +106,8 @@ class TestPqKeyExchangeValidator:
         assert r["is_valid"] is False
         assert r["error"] == "ConnectError"
         assert "could not connect" in r["message"]
+        # Envelope contract: reason accompanies every is_valid: False.
+        assert r["reason"] == r["message"]
 
     def test_unrecognized_probe_shape_is_invalid(self):
         r = self.v.validate(TLS13, {"result": "weird"}, "h", 443)

--- a/tests/test_validators/test_result_envelope.py
+++ b/tests/test_validators/test_result_envelope.py
@@ -1,0 +1,160 @@
+# tests/test_validators/test_result_envelope.py
+
+"""Conformance tests for the standard validator result envelope.
+
+Every PQ validator result must satisfy the contract declared in
+``certmonitor.validators.results.ValidationResult``:
+
+- ``is_valid`` is always present and a strict ``bool`` (never ``None``),
+- ``reason`` is present iff ``is_valid`` is ``False``, and is a
+  non-empty human-readable string,
+- ``warnings``, when present, is a list of strings,
+- the reserved envelope keys are never reused for data.
+
+Legacy validators (e.g. ``key_info``'s ``is_valid: None``) are not yet
+migrated and are intentionally not covered here.
+"""
+
+import sys
+
+import pytest
+
+from certmonitor.validators import ValidationResult
+from certmonitor.validators.pq_chain import PqChainValidator
+from certmonitor.validators.pq_key_exchange import PqKeyExchangeValidator
+from certmonitor.validators.pq_signature import PqSignatureValidator
+
+ML_DSA_65_OID = "2.16.840.1.101.3.4.3.18"
+SHA256_RSA_OID = "1.2.840.113549.1.1.11"
+TLS13 = {"protocol_version": "TLSv1.3"}
+
+
+def assert_envelope(result):
+    """Assert that a validator result conforms to the standard envelope."""
+    assert isinstance(result, dict)
+
+    assert "is_valid" in result, "is_valid must always be present"
+    assert isinstance(result["is_valid"], bool), "is_valid must be a strict bool"
+
+    if result["is_valid"]:
+        assert "reason" not in result, "reason must be absent when valid"
+    else:
+        assert "reason" in result, "reason must be present when invalid"
+        assert isinstance(result["reason"], str) and result["reason"].strip()
+
+    if "warnings" in result:
+        assert isinstance(result["warnings"], list)
+        assert all(isinstance(w, str) for w in result["warnings"])
+
+
+def chain_cert(key_alg, sig_oid, self_signed=False):
+    return {
+        "subject": {"commonName": "x"},
+        "public_key_info": {"algorithm": key_alg, "size": 2048},
+        "signature_algorithm_oid": sig_oid,
+        "is_self_signed": self_signed,
+    }
+
+
+def leaf_data(key_alg, sig_oid):
+    return {"chain_analysis": {"certs": [chain_cert(key_alg, sig_oid)]}}
+
+
+PQ_SIGNATURE_CASES = [
+    leaf_data("ml-dsa-65", ML_DSA_65_OID),  # valid: pure PQ
+    leaf_data("rsaEncryption", SHA256_RSA_OID),  # invalid: classical
+    {},  # invalid: no analysis available at all
+    {"chain_analysis": {"error": "parse failed"}},  # invalid: analysis errored
+]
+
+PQ_CHAIN_CASES = [
+    leaf_data("ml-dsa-65", ML_DSA_65_OID),  # valid: PQ leaf
+    leaf_data("rsaEncryption", SHA256_RSA_OID),  # invalid: classical leaf
+    {"chain_error": "not supported on this interpreter"},  # invalid: chain error
+    {},  # invalid: chain never fetched
+    {"chain_analysis": {"certs": []}},  # invalid: empty chain
+]
+
+PQ_KEY_EXCHANGE_PROBES = [
+    {
+        "result": "group",
+        "id": 4588,
+        "name": "X25519MLKEM768",
+        "kind": "hybrid_pq",
+        "is_pq": True,
+    },
+    {
+        "result": "group",
+        "id": 29,
+        "name": "x25519",
+        "kind": "classical_ecdh",
+        "is_pq": False,
+    },
+    {"result": "n/a", "protocol": "TLSv1.2", "reason": "TLSv1.2 has no PQ KEMs"},
+    {"result": "error", "error": "ConnectError", "message": "could not connect"},
+    {"result": "something-unexpected"},
+]
+
+
+class TestEnvelopeConformance:
+    @pytest.mark.parametrize("cert_data", PQ_SIGNATURE_CASES)
+    def test_pq_signature(self, cert_data):
+        assert_envelope(PqSignatureValidator().validate(cert_data, "h", 443))
+
+    @pytest.mark.parametrize("cert_data", PQ_CHAIN_CASES)
+    def test_pq_chain(self, cert_data):
+        assert_envelope(PqChainValidator().validate(cert_data, "h", 443))
+
+    @pytest.mark.parametrize("probe", PQ_KEY_EXCHANGE_PROBES)
+    def test_pq_key_exchange(self, probe):
+        assert_envelope(PqKeyExchangeValidator().validate(TLS13, probe, "h", 443))
+
+    def test_strict_mode_results_also_conform(self):
+        assert_envelope(
+            PqSignatureValidator().validate(
+                leaf_data("ml-dsa-65", SHA256_RSA_OID),
+                "h",
+                443,
+                require_pq_signature=True,
+            )
+        )
+        assert_envelope(
+            PqChainValidator().validate(
+                leaf_data("ml-dsa-65", SHA256_RSA_OID),
+                "h",
+                443,
+                require_full_chain=True,
+            )
+        )
+
+
+class TestValidationResultSchema:
+    def test_importable_from_validators_package(self):
+        from certmonitor.validators.results import (
+            ValidationResult as FromModule,
+        )
+
+        assert ValidationResult is FromModule
+
+    def test_results_are_plain_dicts_at_runtime(self):
+        # The schema is static-only: results must stay JSON-serializable
+        # plain dicts, not dataclass or TypedDict instances of some
+        # other runtime type.
+        import json
+
+        r = PqSignatureValidator().validate(
+            leaf_data("ml-dsa-65", ML_DSA_65_OID), "h", 443
+        )
+        assert type(r) is dict
+        json.dumps(r)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9),
+        reason="TypedDict.__required_keys__ requires Python 3.9+",
+    )
+    def test_reserved_keys_match_contract(self):
+        # The five reserved envelope keys, exactly.
+        required = set(ValidationResult.__required_keys__)
+        optional = set(ValidationResult.__optional_keys__)
+        assert required == {"is_valid"}
+        assert optional == {"reason", "warnings", "error", "message"}


### PR DESCRIPTION
## Summary

Implements the **standard validator result envelope** amendment from #28 — the last in-scope item of that plan. The contract that previously existed only as an issue comment is now code, tests, and docs.

### The schema, as a class — why `TypedDict` and not a `@dataclass`

Validators return plain dicts, and everything downstream (`results["is_valid"]`, `json.dumps`, every test and docs example) depends on that. A dataclass would change the runtime type and break all of it. `ValidationResult` (new `certmonitor/validators/results.py`) declares the schema as a `TypedDict`: mypy enforces the shape statically while the objects stay ordinary JSON-serializable dicts. The two-class required/optional split is used because `typing.NotRequired` doesn't exist on 3.8 and the project takes no dependencies (`typing_extensions` included).

### The contract

| Key | Type | Rule |
|---|---|---|
| `is_valid` | `bool` | Always present, strict bool — never `None` |
| `reason` | `str` | Present **iff** `is_valid` is `False` |
| `warnings` | `List[str]` | Optional; non-fatal findings |
| `error` / `message` | `str` | Optional; machine-readable class + detail on operational failures |

All other keys are validator-specific data fields; the five reserved keys are never reused for data.

### Changes

- **`validators/results.py`** — the envelope `TypedDict`, with the contract documented in the module docstring. Re-exported as `certmonitor.validators.ValidationResult`.
- **Base classes** — `validate()` return type relaxed `Dict[str, Any]` → `Mapping[str, Any]`: mypy deems a TypedDict assignable to `Mapping` but not `Dict`, so this is what lets overrides annotate precise shapes. Legacy validators returning `Dict[str, Any]` still conform unchanged (`Dict` is a `Mapping`), and `core.py` already casts at the dynamic-dispatch boundary — zero runtime change.
- **Per-validator schemas** — `PqSignatureResult`, `PqChainResult`, `PqKeyExchangeResult` extend the base so the data fields are mypy-checked too.
- **One conformance fix** — `pq_key_exchange`'s probe-error path returned `{error, message, is_valid: False}` with no `reason`, violating "`reason` iff invalid". It now carries `reason` alongside the machine-readable `error`/`message`.
- **Docs** — the contract gets a section in the validators overview (with legacy shapes — e.g. `key_info`'s `is_valid: None` — explicitly noted as not yet migrated); the PQ validators are added to the overview list (nav had them, the page didn't).
- **Custom-validator guide rewritten** — the example predated the dispatcher's keyword-only user-arg enforcement (PR #41) and would now raise `TypeError` at import; it also used the deprecated bare-list args form and emitted `reason` on valid results. The new example declares its own result TypedDict and was verified to run against the real base class.

### Tests

New envelope conformance suite (`test_result_envelope.py`) drives all three PQ validators across valid / invalid / operational-error / strict-mode paths, asserts results are plain dicts (`type(r) is dict` + `json.dumps`), and pins the reserved-key set exactly (3.9+ guard for `__required_keys__` introspection, which doesn't exist on 3.8). Existing probe-error test extended to pin the new `reason` key.

**529 tests pass; ruff, ruff format, mypy (strict config, `python_version = 3.8`), and `mkdocs build --strict` all green.**

### Out of scope (by the amendment's own terms)

Migrating legacy validators to the envelope — stays behind a future deprecation cycle.

Refs #28.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnpQmB3vEZ5754cETdj7UU)_