### PR TITLE
docs(validators): flow diagrams + enriched overview (PQ framing, real output examples)

### DIFF
--- a/docs/validators/chain.md
+++ b/docs/validators/chain.md
@@ -37,6 +37,21 @@ Pass via `validator_args={"chain": {...}}`:
 
 The default weak-signature set includes `sha1WithRSAEncryption`, `md5WithRSAEncryption`, `md2WithRSAEncryption`, `ecdsa-with-SHA1`, and `dsa-with-sha1`.
 
+## How it decides
+
+The chain is fetched, each certificate is inspected, and `is_valid` is the AND of every structural condition. Per-certificate warnings are collected regardless; on failure the first warning becomes the top-level `reason`.
+
+```mermaid
+flowchart TD
+    A[validate called] --> B{Chain fetched?<br/>Python 3.10+, no error}
+    B -- No --> Z["is_valid: false + reason"]
+    B -- Yes --> C[Inspect each certificate:<br/>expiry, weak signature, CA flag, role]
+    C --> D{All structural conditions hold?}
+    D --> D1["length &ge; min_chain_length<br/>chain ordered<br/>no expired / not-yet-valid member<br/>leaf not self-signed unless allowed<br/>terminates in root if required"]
+    D1 -- All true --> G["is_valid: true"]
+    D1 -- Any false --> H["is_valid: false<br/>reason = first warning"]
+```
+
 ## Output
 
 ```json
@@ -59,7 +74,7 @@ The default weak-signature set includes `sha1WithRSAEncryption`, `md5WithRSAEncr
       "signature_algorithm_oid": "1.2.840.113549.1.1.11",
       "subject_key_identifier": "ac33ac35b5f88ae27b06d23dc7058997d81c2443",
       "authority_key_identifier": "de1b1eed7915d43e3724c321bbec34396d42b230",
-      "public_key_info": {"algorithm": "ecPublicKey", "size": 256, "curve": "1.2.840.10045.2.1"},
+      "public_key_info": {"algorithm": "ecPublicKey", "size": 256, "curve": "secp256r1"},
       "warnings": []
     }
   ],

--- a/docs/validators/index.md
+++ b/docs/validators/index.md
@@ -1,30 +1,113 @@
 # Validators Overview
 
-CertMonitor provides a modular validator system to check various aspects of SSL/TLS certificates and connections. Each validator can be enabled or disabled as needed, and some accept additional arguments for fine-grained control.
+CertMonitor provides a modular validator system to check various aspects of SSL/TLS certificates and connections. Each validator returns a structured, JSON-serializable result — not a bare pass/fail — so you can drive alerts, dashboards, and policy from rich data. Validators can be enabled or disabled per call, and some accept arguments for fine-grained control.
 
-Available validators:
+This includes **post-quantum readiness**: opt-in validators report whether the TLS key exchange and the certificate's keys/signatures use post-quantum algorithms (hybrid or pure ML-KEM / ML-DSA / SLH-DSA), so you can track quantum-safe migration and *harvest-now-decrypt-later* exposure. See [Post-Quantum Readiness](#post-quantum-readiness) below.
+
+## Available validators
+
+**Enabled by default** (`expiration`, `hostname`, `root_certificate`):
 
 - [Expiration](expiration.md): Checks if the certificate is expired or expiring soon.
 - [Hostname](hostname.md): Validates that the certificate matches the expected hostname.
-- [SubjectAltNames](subject_alt_names.md): Checks the Subject Alternative Names (SANs) extension.
 - [RootCertificate](root_certificate.md): Checks if the certificate is issued by a trusted root CA.
-- [KeyInfo](key_info.md): Validates the public key type and strength.
+
+**Opt-in** (enable via `enabled_validators=[...]` or `ENABLED_VALIDATORS`):
+
+- [SubjectAltNames](subject_alt_names.md): Checks the Subject Alternative Names (SANs) extension.
+- [KeyInfo](key_info.md): Validates the public key type and strength (RSA / EC / post-quantum).
 - [TLSVersion](tls_version.md): Validates the negotiated TLS version.
 - [WeakCipher](weak_cipher.md): Validates that the negotiated cipher suite is in the allowed list.
 - [SensitiveDate](sensitive_date.md): Validates that the certificate doesn't expire on built-in or user specified sensitive dates.
-- [Chain](chain.md): Inspects the full TLS certificate chain for structural problems (missing intermediates, out-of-order, expired members). Opt-in; requires Python 3.10+.
-- [PqKeyExchange](pq_key_exchange.md): Judges whether the negotiated TLS key exchange is post-quantum (hybrid or pure ML-KEM). Opt-in.
-- [PqChain](pq_chain.md): Reports the post-quantum posture of every certificate in the presented chain. Opt-in; requires Python 3.10+.
-- [PqSignature](pq_signature.md): Judges the leaf certificate's post-quantum posture (key and signature algorithm). Opt-in.
+- [Chain](chain.md): Inspects the full TLS certificate chain for structural problems (missing intermediates, out-of-order, expired members). Requires Python 3.10+.
+- [PqKeyExchange](pq_key_exchange.md): Judges whether the negotiated TLS key exchange is post-quantum (hybrid or pure ML-KEM).
+- [PqChain](pq_chain.md): Reports the post-quantum posture of every certificate in the presented chain. Requires Python 3.10+.
+- [PqSignature](pq_signature.md): Judges the leaf certificate's post-quantum posture (key and signature algorithm).
 
-See each page for usage and output examples.
+## What the output looks like
+
+Validators return data, not just a boolean. Enable the ones you want and read the structured results:
+
+```python
+from certmonitor import CertMonitor
+
+with CertMonitor(
+    "example.com",
+    enabled_validators=["expiration", "key_info", "tls_version", "weak_cipher"],
+) as monitor:
+    monitor.get_cert_info()
+    results = monitor.validate()
+```
+
+```json
+{
+  "expiration": {
+    "is_valid": true,
+    "days_to_expiry": 56,
+    "expires_on": "2026-08-08T22:14:02+00:00",
+    "warnings": []
+  },
+  "key_info": {
+    "key_type": "ecPublicKey",
+    "key_size": 256,
+    "is_valid": true,
+    "curve": "secp256r1"
+  },
+  "tls_version": {
+    "is_valid": true,
+    "protocol_version": "TLSv1.3"
+  },
+  "weak_cipher": {
+    "is_valid": true,
+    "cipher_suite": "TLS_AES_256_GCM_SHA384"
+  }
+}
+```
+
+When a check fails, the same envelope carries a human-readable `reason` you can surface directly in an alert:
+
+```json
+{
+  "expiration": {
+    "is_valid": false,
+    "days_to_expiry": -4080,
+    "expires_on": "2015-04-12T23:59:59+00:00",
+    "warnings": ["Certificate is expired and has been expired for (-4080 days)"],
+    "reason": "Certificate expired 4080 days ago (expired on 2015-04-12)."
+  }
+}
+```
+
+Because every validator's result is a plain dict keyed by validator name, a monitoring pipeline can do `if not results["expiration"]["is_valid"]: alert(results["expiration"]["reason"])` without special-casing.
+
+## Post-Quantum Readiness
+
+The `pq_*` validators answer the questions classical TLS tooling can't. `pq_key_exchange` reads the negotiated TLS 1.3 group directly off the wire — the Python `ssl` module doesn't expose it — and tells you whether the session is protected against *harvest-now-decrypt-later*:
+
+```python
+with CertMonitor("cloudflare.com", enabled_validators=["pq_key_exchange"]) as monitor:
+    monitor.get_cert_info()
+    print(monitor.validate()["pq_key_exchange"])
+```
+
+```json
+{
+  "kem_id": 4588,
+  "kem_name": "X25519MLKEM768",
+  "kem_kind": "hybrid_pq",
+  "is_pq": true,
+  "is_valid": true
+}
+```
+
+`pq_signature` and `pq_chain` report the post-quantum posture of the leaf and the full chain as CAs roll out ML-DSA / SLH-DSA and composite certificates. All three are opt-in while PQC adoption ramps. See their pages for the decision flows and field-by-field output.
 
 ## The result contract
 
-Every validator returns a plain, JSON-serializable dict. Results from the
-post-quantum validators conform to a standard envelope, declared as a
-`TypedDict` in `certmonitor.validators.results.ValidationResult` so mypy can
-enforce it without changing the runtime type:
+Every validator returns a plain, JSON-serializable dict. **All** validators
+conform to a standard envelope, declared as a `TypedDict` in
+`certmonitor.validators.results.ValidationResult` so mypy can enforce it
+without changing the runtime type:
 
 | Key | Type | Rule |
 |---|---|---|
@@ -49,11 +132,10 @@ Two corollaries:
    extending `ValidationResult` with its data fields (see
    `pq_signature.py` for an example); the value your code receives is still
    an ordinary dict.
-
-The pre-existing validators (`expiration`, `key_info`, …) predate this
-contract and keep their legacy shapes for now — notably `key_info` may
-return `is_valid: None` for unknown key types. They will migrate behind a
-deprecation cycle.
+3. **`is_valid` is always a strict `bool`.** When a validator cannot
+   determine an answer (e.g. `key_info` facing an unrecognized algorithm),
+   it fails closed — `is_valid: False` with an explanatory `reason` — rather
+   than returning `None`.
 
 ---
 

--- a/docs/validators/key_info.md
+++ b/docs/validators/key_info.md
@@ -1,3 +1,30 @@
 # KeyInfo Validator
 
+The `key_info` validator judges the strength of the certificate's public key, per algorithm family:
+
+- **RSA** — modulus must be at least 2048 bits.
+- **EC** — curve must be one of `secp256r1`, `secp384r1`, `secp521r1`.
+- **Post-quantum** (ML-DSA, SLH-DSA, composite ML-DSA) — strong by algorithm identity; the FIPS 204/205 parameter sets have no weak sizes or curves. The recognized set comes from the Rust registry via `certinfo.pq_algorithms()`.
+
+Per the result envelope, `is_valid` is always a strict `bool`. When strength **cannot be determined** (an unrecognized algorithm, or a missing size/curve) the key **fails closed** — `is_valid: false` with a `reason` that distinguishes "cannot determine" from "recognized but weak".
+
+## How it decides
+
+```mermaid
+flowchart TD
+    A[validate called] --> B{public_key_info present?}
+    B -- No --> Z["is_valid: false<br/>cannot extract key info"]
+    B -- Yes --> C{Algorithm family?}
+    C -- "Post-quantum<br/>(ML-DSA / SLH-DSA / composite)" --> D["is_valid: true<br/>strong by identity"]
+    C -- RSA --> E{Modulus &ge; 2048 bits?}
+    E -- Yes --> D
+    E -- "No / size missing" --> F["is_valid: false + reason"]
+    C -- EC --> H{Curve in approved set?<br/>secp256r1 / secp384r1 / secp521r1}
+    H -- Yes --> D
+    H -- "No / curve missing" --> F
+    C -- "Other / unknown" --> K["is_valid: false<br/>cannot determine — fails closed"]
+```
+
+## API
+
 ::: certmonitor.validators.key_info.KeyInfoValidator

--- a/docs/validators/pq_chain.md
+++ b/docs/validators/pq_chain.md
@@ -37,6 +37,26 @@ with CertMonitor("example.com", enabled_validators=["pq_chain"]) as m:
 Chain retrieval requires Python 3.10+ (same constraint as the `chain`
 validator); older interpreters get a structured error.
 
+## How it decides
+
+Each link is classified independently, then the verdict keys off the leaf
+key by default (or the whole chain with `require_full_chain`).
+
+```mermaid
+flowchart TD
+    A[validate called] --> B{Chain available?<br/>Python 3.10+}
+    B -- No --> Z["structured error"]
+    B -- Yes --> C[For each certificate:<br/>is_pq = key_is_pq OR signature_is_pq]
+    C --> D[Summarize by role:<br/>leaf_pq / intermediate_pq / root_pq]
+    D --> E{require_full_chain?}
+    E -- "false (default)" --> F{Leaf key<br/>post-quantum?}
+    F -- Yes --> G["is_valid: true"]
+    F -- No --> H["is_valid: false"]
+    E -- true --> I{Every certificate<br/>is_pq?}
+    I -- Yes --> G
+    I -- No --> H
+```
+
 ## Example output
 
 A post-quantum leaf on a classical chain (the realistic migration shape):

--- a/docs/validators/pq_key_exchange.md
+++ b/docs/validators/pq_key_exchange.md
@@ -44,6 +44,21 @@ is determined without any extra connection.
 connection to the host; IDS/rate-limiters may observe it. This is one
 reason the validator is opt-in.
 
+## How it decides
+
+```mermaid
+flowchart TD
+    A[validate called] --> B{Primary connection<br/>negotiated TLS 1.3?}
+    B -- "No (TLS 1.2 or older)" --> N["is_valid: false<br/>kem_kind: n/a<br/><b>no second connection</b>"]
+    B -- Yes --> C[Probe: open 2nd TCP connection,<br/>send TLS 1.3 ClientHello<br/>offering PQ groups]
+    C --> D{Probe result}
+    D -- error --> E["is_valid: false<br/>error + message + reason"]
+    D -- n/a --> N
+    D -- group --> F{Negotiated group<br/>post-quantum?}
+    F -- "Yes — hybrid or pure ML-KEM" --> G["is_valid: true<br/>is_pq: true"]
+    F -- "No — classical ECDH" --> H["is_valid: false<br/>classical KEX — HNDL-exposed"]
+```
+
 ## Example output
 
 Hybrid PQ (pass):

--- a/docs/validators/pq_signature.md
+++ b/docs/validators/pq_signature.md
@@ -36,6 +36,28 @@ with CertMonitor("example.com", enabled_validators=["pq_signature"]) as m:
 #   m.validate(validator_args={"pq_signature": {"require_pq_signature": True}})
 ```
 
+## How it decides
+
+The key and the signature are judged separately; `is_valid` keys off the
+leaf **key** by default (the part the operator controls).
+
+```mermaid
+flowchart TD
+    A[validate called] --> B{Leaf analysis<br/>available?}
+    B -- No --> Z["is_valid: false<br/>leaf could not be analyzed"]
+    B -- Yes --> C[Read leaf key algorithm<br/>and signature OID]
+    C --> D{Leaf key<br/>post-quantum?}
+    D -- No --> F["is_valid: false<br/>key not post-quantum"]
+    D -- Yes --> E{require_pq_signature?}
+    E -- "false (default)" --> G["is_valid: true"]
+    E -- true --> H{CA signature<br/>post-quantum?}
+    H -- Yes --> G
+    H -- No --> I["is_valid: false<br/>CA signature not post-quantum"]
+```
+
+`is_pq` (reported separately from `is_valid`) is true when **either** the
+key or the signature is post-quantum.
+
 ## Example output
 
 A post-quantum leaf, classically signed (the realistic migration shape):


### PR DESCRIPTION
Reviewed all validator docs and improved them in two ways.

## 1. Flow diagrams for the branching validators

Added Mermaid decision-flow diagrams where the logic genuinely branches and prose/tables don't make it obvious (matches the `flowchart TD` style already used in usage docs):

| Validator | Why |
|---|---|
| **pq_key_exchange** | skip-for-legacy → second-connection probe → classify (hard to follow from the table alone). |
| **pq_signature** | the `is_valid` decision tree (leaf key vs `require_pq_signature`). |
| **pq_chain** | per-cert `is_pq` → role summary → verdict (`require_full_chain`). |
| **chain** | the structural pass/fail decision. |
| **key_info** | per-family strength decision; this page was a bare API include, so it also gained intro prose. |

Linear validators (`expiration`, `hostname`, `subject_alt_names`, `tls_version`, `weak_cipher`, `root_certificate`) reviewed and left as-is — a diagram there would be noise.

## 2. Enriched the validators overview page

- **Post-quantum framing** up front + a dedicated section, so PQ is visible on the landing page rather than only the per-validator pages.
- **Real `validate()` output examples** — a healthy multi-validator result, a failure carrying a human-readable `reason`, and a hybrid-PQ key-exchange result — replacing the previous "see each page" hand-wave. Shows the structured power of validators instead of implying it.
- **Grouped validators by default-enabled vs opt-in** (the default set is just `expiration`/`hostname`/`root_certificate`).

## Stale content fixed

- `chain.md` example showed `"curve": "1.2.840.10045.2.1"` (pre-#49 OID format, and the wrong OID) → now `secp256r1`.
- Overview "result contract" said only the PQ validators conform and that `key_info` "may return `is_valid: None`" — both obsolete after the envelope migration (#51). Now states all validators conform and `is_valid` is always a strict bool (fails closed).

## Validation

- `mkdocs build --strict` passes.
- All diagrams render as `class="mermaid"` divs; output examples are captured from real live runs.
- No build artifacts committed.