### PR TITLE
docs: correct stale stats and Rust dependency description

### DIFF
--- a/MODULARIZATION_REPORT.md
+++ b/MODULARIZATION_REPORT.md
@@ -10,14 +10,14 @@
 
 ### Test Coverage
 - **Overall coverage:** 98.7%
-- **Total tests:** 522
-- **Statements covered:** 1,115/1,130
-- **Files with coverage:** 25
+- **Total tests:** 540
+- **Statements covered:** 1,212/1,228
+- **Files with coverage:** 27
 
 ### Type Hint Coverage
-- **Files analyzed:** 22
-- **Files with type hints:** 20
-- **Type hint coverage:** 90.9%
+- **Files analyzed:** 23
+- **Files with type hints:** 21
+- **Type hint coverage:** 91.3%
 
 ### Code Quality
 - **Ruff issues:** 0
@@ -29,8 +29,8 @@
 - **Rust vulnerabilities found:** 0
 - **Python security scanning:** ✅ Enabled
 - **Python security issues found:** 0
-- **Files scanned by bandit:** 25
-- **Lines scanned by bandit:** 2,843
+- **Files scanned by bandit:** 27
+- **Lines scanned by bandit:** 3,039
 - **Overall security status:** 🔒 Clean
 - **PyO3 version:** 0.29
 
@@ -71,19 +71,20 @@
 - **protocol_handlers/ssh_handler.py**: ✅ (77 lines)
 - **protocol_handlers/base.py**: ✅ (28 lines)
 - **utils/utils.py**: ❌ (1 lines)
-- **validators/weak_cipher.py**: ✅ (68 lines)
-- **validators/pq_chain.py**: ✅ (190 lines)
-- **validators/sensitive_date.py**: ✅ (204 lines)
-- **validators/subject_alt_names.py**: ✅ (239 lines)
-- **validators/chain.py**: ✅ (302 lines)
-- **validators/expiration.py**: ✅ (87 lines)
-- **validators/pq_key_exchange.py**: ✅ (141 lines)
-- **validators/root_certificate_validator.py**: ✅ (113 lines)
-- **validators/pq_signature.py**: ✅ (174 lines)
-- **validators/tls_version.py**: ✅ (70 lines)
-- **validators/key_info.py**: ✅ (158 lines)
-- **validators/base.py**: ✅ (149 lines)
-- **validators/hostname.py**: ✅ (148 lines)
+- **validators/weak_cipher.py**: ✅ (75 lines)
+- **validators/pq_chain.py**: ✅ (199 lines)
+- **validators/sensitive_date.py**: ✅ (220 lines)
+- **validators/subject_alt_names.py**: ✅ (253 lines)
+- **validators/results.py**: ✅ (70 lines)
+- **validators/chain.py**: ✅ (313 lines)
+- **validators/expiration.py**: ✅ (102 lines)
+- **validators/pq_key_exchange.py**: ✅ (157 lines)
+- **validators/root_certificate_validator.py**: ✅ (129 lines)
+- **validators/pq_signature.py**: ✅ (186 lines)
+- **validators/tls_version.py**: ✅ (77 lines)
+- **validators/key_info.py**: ✅ (204 lines)
+- **validators/base.py**: ✅ (156 lines)
+- **validators/hostname.py**: ✅ (156 lines)
 - **validators/_utils.py**: ✅ (23 lines)
 
 ---

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ CertMonitor's certificate parser handles untrusted bytes from every TLS handshak
 - **Every parser path returns `Result`.** Malformed input produces a structured error, never a crash. No `.unwrap()` on user-input-derived data.
 - **1.7 billion fuzz iterations, zero crashes.** The parser is continuously fuzz-tested with [cargo-fuzz](https://github.com/rust-lang/cargo-fuzz) (libFuzzer) against adversarial byte sequences. A 1-hour soak run explores 310 code-coverage points and 503 libfuzzer features with zero panics. Run it yourself: `make fuzz`.
 - **130-cert real-world corpus on every CI run.** Every commit is tested against captured certificates from 101 production hosts spanning Google Trust Services, DigiCert, Let's Encrypt, Sectigo, Cloudflare, and more, covering both RSA and ECDSA key types.
-- **425+ Python tests at 99% line coverage, 56 Rust unit tests.** The full test suite runs across Python 3.8 to 3.13 and Rust stable on macOS, Ubuntu, and Windows.
-- **`cargo audit` on every PR.** The Rust dependency tree is 20 crates total (all PyO3 build-time helpers), scanned for known vulnerabilities on every pull request.
+- **540+ Python tests at 99% line coverage, plus 99 Rust unit tests.** The full test suite runs across Python 3.8 to 3.13 and Rust stable on macOS, Ubuntu, and Windows.
+- **`cargo audit` on every PR.** CertMonitor declares a single direct Rust dependency, `pyo3` (the Python bridge). The whole compiled tree is 15 crates, all pyo3 and its helpers, with no third-party parsing crates, scanned for known vulnerabilities on every pull request.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -250,8 +250,8 @@ CertMonitor's certificate parser handles untrusted bytes from every TLS handshak
 - **Every parser path returns `Result`.** Malformed input produces a structured error, never a crash. No `.unwrap()` on user-input-derived data.
 - **1.7 billion fuzz iterations, zero crashes.** The parser is continuously fuzz-tested with [cargo-fuzz](https://github.com/rust-lang/cargo-fuzz) (libFuzzer) against adversarial byte sequences. A 1-hour soak run explores 310 code-coverage points and 503 libfuzzer features with zero panics. Run it yourself: `make fuzz`.
 - **130-cert real-world corpus on every CI run.** Every commit is tested against captured certificates from 101 production hosts spanning Google Trust Services, DigiCert, Let's Encrypt, Sectigo, Cloudflare, and more, covering both RSA and ECDSA key types.
-- **425+ Python tests at 99% line coverage, 56 Rust unit tests.** The full test suite runs across Python 3.8 to 3.13 and Rust stable on macOS, Ubuntu, and Windows.
-- **`cargo audit` on every PR.** The Rust dependency tree is 20 crates total (all PyO3 build-time helpers), scanned for known vulnerabilities on every pull request.
+- **540+ Python tests at 99% line coverage, plus 99 Rust unit tests.** The full test suite runs across Python 3.8 to 3.13 and Rust stable on macOS, Ubuntu, and Windows.
+- **`cargo audit` on every PR.** CertMonitor declares a single direct Rust dependency, `pyo3` (the Python bridge). The whole compiled tree is 15 crates, all pyo3 and its helpers, with no third-party parsing crates, scanned for known vulnerabilities on every pull request.
 
 ---
 

--- a/docs/usage/full_workflow.md
+++ b/docs/usage/full_workflow.md
@@ -64,7 +64,7 @@ Here's roughly what each call gives you back. The output is trimmed for readabil
 ```json
 {
   "expiration": {"is_valid": true, "days_to_expiry": 120, "expires_on": "2025-09-01T23:59:59", "warnings": []},
-  "subject_alt_names": {"is_valid": true, "sans": {"DNS": ["example.com", "www.example.com"], "IP Address": []}, "count": 2, "contains_host": {"name": "example.com", "is_valid": true, "reason": "Matched DNS SAN"}, "contains_alternate": {"www.example.com": {"name": "www.example.com", "is_valid": true, "reason": "Matched DNS SAN"}}, "warnings": []}
+  "subject_alt_names": {"is_valid": true, "sans": {"DNS": ["example.com", "www.example.com"], "IP Address": []}, "count": 2, "contains_host": {"name": "example.com", "is_valid": true, "reason": "Exact match for example.com found in DNS SANs"}, "contains_alternate": {"www.example.com": {"name": "www.example.com", "is_valid": true, "reason": "Exact match for www.example.com found in DNS SANs"}}, "warnings": []}
   // ...
 }
 ```


### PR DESCRIPTION
Follow-up audit of the docs for factual drift against the codebase.

## Fixed

- **Rust unit tests:** "56" → **99** (actual `cargo test --lib`).
- **Python tests:** "425+" → **540+** (actual collected count).
- **Rust dependency description:** "20 crates total (all PyO3 build-time helpers)" was wrong twice over. The tree is **15 crates** after the pyo3 0.24→0.29 upgrade, and they are not all build-time: `pyo3`, `pyo3-ffi`, `libc`, `once_cell` are runtime (compiled into the wheel), while the proc-macro/codegen crates are build-time. Reworded to the accurate point: CertMonitor declares a **single direct Rust dependency** (`pyo3`); the whole tree is 15 crates with no third-party parsing crates. Applied to both the README and the docs home page.
- **Leftover placeholder reason:** `full_workflow.md` still showed `"reason": "Matched DNS SAN"`; corrected to the real string `"Exact match ... found in DNS SANs"`.

## Verified accurate (no change needed)

- 130-cert real-world corpus (counted).
- All documented validator arguments exist (`require_pq_signature`, `require_full_chain`, `alternate_names`, chain args).
- Python 3.8–3.13 range matches `pyproject.toml`.
- Every `monitor.*()` method referenced in the docs exists on `CertMonitor`.

`mkdocs build --strict` clean; zero em dashes.