### PR TITLE
fix(rust): silence dead_code warning for curve_name in no-python builds

### DIFF
--- a/rust_certinfo/src/der/oid.rs
+++ b/rust_certinfo/src/der/oid.rs
@@ -113,6 +113,12 @@ pub const OID_SECP256K1: &[u8] = &[0x2b, 0x81, 0x04, 0x00, 0x0a];
 /// name rather than a raw OID; unknown curves fall back to the dotted
 /// OID string. This keeps curve identity in one place (next to the OID
 /// constants) instead of duplicated in the Python layer.
+///
+/// Its only non-test caller is the PyO3 layer (`pyobj`), which is gated
+/// behind the `python` feature. Without that feature (e.g. the fuzz
+/// crate's `--no-default-features` build) this is unused, so suppress the
+/// dead-code warning in exactly that configuration.
+#[cfg_attr(not(feature = "python"), allow(dead_code))]
 pub fn curve_name(oid: Oid<'_>) -> Option<&'static str> {
     match oid.as_bytes() {
         b if b == OID_SECP256R1 => Some("secp256r1"),


### PR DESCRIPTION
## What

`make fuzz` surfaced a warning:

```
warning: function `curve_name` is never used
 --> rust_certinfo/src/der/oid.rs:116:8
```

## Why

`curve_name()`'s only non-test caller is the PyO3 layer (`pyobj`), which is gated behind the `python` feature. The fuzz crate builds with `--no-default-features`, so `pyobj` isn't compiled and `curve_name` looks dead in that one configuration. It is fully used in the shipped extension, which is why `cargo clippy --all-features` (CI) never flagged it.

Not a functional problem: the EC-curve-name behavior works in the wheel. Just a build-warning in the no-python config.

## Fix

`#[cfg_attr(not(feature = "python"), allow(dead_code))]` on `curve_name`, suppressing the warning only when the `python` feature is off.

## Verified

- `cargo build --no-default-features` (fuzz config): no warning.
- `cargo build` (default/python): clean, `curve_name` used.
- `cargo clippy --all-targets --all-features -D warnings`: clean.
- `cargo test --lib`: 99 passed.