### PR TITLE
docs: correct cipher_info examples to match actual output

### DIFF
--- a/certmonitor/cipher_algorithms.py
+++ b/certmonitor/cipher_algorithms.py
@@ -124,7 +124,7 @@ ALLOWED_CIPHER_SUITES = {
     "ECDHE-ECDSA-AES256-GCM-SHA384",
     "ECDHE-RSA-AES256-GCM-SHA384",
     # TLS 1.3 (IANA names, as reported by Python's ssl module). ALLOWED_TLS_VERSIONS
-    # permits TLS 1.3, so its cipher suites must be allowed too — otherwise every
+    # permits TLS 1.3, so its cipher suites must be allowed too, otherwise every
     # TLS 1.3 connection (the modern default) is flagged weak on its strongest config.
     "TLS_AES_128_GCM_SHA256",
     "TLS_AES_256_GCM_SHA384",

--- a/docs/usage/basic.md
+++ b/docs/usage/basic.md
@@ -123,8 +123,8 @@ Here's what that looks like:
 {
   "cipher_suite": {
     "name": "TLS_AES_256_GCM_SHA384",
-    "encryption_algorithm": "AES-256-GCM",
-    "message_authentication_code": "AEAD",
+    "encryption_algorithm": "AES",
+    "message_authentication_code": "SHA384",
     "key_exchange_algorithm": "Not applicable (TLS 1.3 uses ephemeral key exchange by default)"
   },
   "protocol_version": "TLSv1.3",

--- a/docs/usage/cipher.md
+++ b/docs/usage/cipher.md
@@ -21,8 +21,8 @@ with CertMonitor("example.com") as monitor:
 {
   "cipher_suite": {
     "name": "TLS_AES_256_GCM_SHA384",
-    "encryption_algorithm": "AES-256-GCM",
-    "message_authentication_code": "AEAD",
+    "encryption_algorithm": "AES",
+    "message_authentication_code": "SHA384",
     "key_exchange_algorithm": "Not applicable (TLS 1.3 uses ephemeral key exchange by default)"
   },
   "protocol_version": "TLSv1.3",

--- a/docs/usage/full_workflow.md
+++ b/docs/usage/full_workflow.md
@@ -74,8 +74,8 @@ Here's roughly what each call gives you back. The output is trimmed for readabil
 {
   "cipher_suite": {
     "name": "TLS_AES_256_GCM_SHA384",
-    "encryption_algorithm": "AES-256-GCM",
-    "message_authentication_code": "AEAD",
+    "encryption_algorithm": "AES",
+    "message_authentication_code": "SHA384",
     "key_exchange_algorithm": "Not applicable (TLS 1.3 uses ephemeral key exchange by default)"
   },
   "protocol_version": "TLSv1.3",


### PR DESCRIPTION
Review of `cipher_algorithms.py` for currency (per request).

## The module is up to date
- `ALLOWED_CIPHER_SUITES` follows Mozilla "Intermediate" (the six TLS 1.2 AEAD suites + the three TLS 1.3 suites); `ALLOWED_TLS_VERSIONS` is `{TLSv1.2, TLSv1.3}`.
- The algorithm patterns are comprehensive and modern (AES, CHACHA20, ARIA, SM4, GOST, etc.).
- `parse_cipher_suite` reporting the PRF hash as `mac` for AEAD suites that name one (and only falling back to `"AEAD"` when the name has no hash, e.g. `DHE-RSA-AES-GCM`) is intentional and unit-tested.

## The drift was in the docs
`get_cipher_info()` actually returns, for `TLS_AES_256_GCM_SHA384`:

```json
"encryption_algorithm": "AES",
"message_authentication_code": "SHA384"
```

but `cipher.md`, `basic.md`, and `full_workflow.md` showed `"AES-256-GCM"` and `"AEAD"`. Corrected all three to the real values (verified live against a TLS 1.3 host).

Also removed an em dash from a comment in `cipher_algorithms.py`.

## Verified
- `pytest tests/test_cipher_algorithms.py` (21 pass), full suite green.
- `mkdocs build --strict` clean.