### PR TITLE
feat: Python 3.10+ baseline (drop 3.8/3.9, add 3.14/3.15) — 0.5.0

### DIFF
--- a/.github/instructions/certmonitor.instructions.md
+++ b/.github/instructions/certmonitor.instructions.md
@@ -4,7 +4,7 @@ applyTo: '**'
 Coding standards, domain knowledge, and preferences that AI should follow.
 
 # Coding Standards
-- Use Python 3.8+.
+- Use Python 3.10+.
 - Use type hints.
 - Use f-strings for string formatting.
 - Use `ruff` for formatting and linting.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,14 @@ jobs:
         run: |
           uv run pip install mypy types-requests
           uv run mypy certmonitor/ --ignore-missing-imports --show-error-codes
-          
+
+      # Informational only: ty is astral's preview (0.0.x) type checker. It is
+      # stricter than mypy (e.g. on validator LSP), so it does not gate merges
+      # yet. Tracked so we can watch it mature toward a future migration.
+      - name: Type checking with ty (advisory, non-blocking)
+        continue-on-error: true
+        run: uvx ty check certmonitor/
+
       - name: Check code complexity
         run: |
           uv run pip install radon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,17 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.6.17"
+          enable-cache: true
           
       - name: Install dependencies
         run: uv sync --group dev
@@ -60,21 +60,22 @@ jobs:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.event_name == 'release'
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]  # Full Python matrix
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]  # Full Python matrix
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.6.17"
+          enable-cache: true
           
       - name: Install dependencies
         run: uv sync --group dev
@@ -89,11 +90,12 @@ jobs:
             
       - name: Upload coverage (Python 3.11 only)
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: certmonitor-coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
       
       - name: Build verification (Python 3.11 only)
         if: matrix.python-version == '3.11'
@@ -110,17 +112,17 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.6.17"
+          enable-cache: true
           
       - name: Install dependencies
         run: uv sync --group dev
@@ -168,7 +170,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -214,17 +216,17 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.6.17"
+          enable-cache: true
           
       - name: Install dependencies
         run: uv sync --group dev
@@ -262,17 +264,17 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.6.17"
+          enable-cache: true
           
       - name: Install dependencies
         run: uv sync --group docs
@@ -295,15 +297,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v8
         with:
-          version: "0.6.17"
+          enable-cache: true
       - name: Create venv
         run: |
           uv venv .venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,13 @@ jobs:
           uv run pip install mypy types-requests
           uv run mypy certmonitor/ --ignore-missing-imports --show-error-codes
 
-      # Informational only: ty is astral's preview (0.0.x) type checker. It is
-      # stricter than mypy (e.g. on validator LSP), so it does not gate merges
-      # yet. Tracked so we can watch it mature toward a future migration.
-      - name: Type checking with ty (advisory, non-blocking)
-        continue-on-error: true
-        run: uvx ty check certmonitor/
+      # FUTURE: consider running astral's `ty` type checker here once it
+      # stabilizes (currently a 0.0.x preview). It is stricter than mypy
+      # (e.g. on the validator override signatures), so it is not wired into
+      # CI yet. Run it locally with `make typecheck-ty` to see its output.
+      # - name: Type checking with ty (advisory, non-blocking)
+      #   continue-on-error: true
+      #   run: uvx ty check certmonitor/
 
       - name: Check code complexity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           
@@ -73,7 +73,7 @@ jobs:
           allow-prereleases: true
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           
@@ -120,7 +120,7 @@ jobs:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           
@@ -224,7 +224,7 @@ jobs:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           
@@ -272,7 +272,7 @@ jobs:
           python-version: "3.11"
           
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           
@@ -303,7 +303,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Create venv

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: Release v${{ steps.extract-release-notes.outputs.version }}
           body_path: release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ rename the headers to emoji form when cutting a release.
 - Raised the Rust extension's abi3 floor to `abi3-py310` to match the new Python minimum.
 - CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8.2.0, codecov v5 with token upload, action-gh-release v2).
 - `make test` now runs the Rust unit tests (`cargo test`) as part of the local CI-equivalent suite; previously they ran only in CI.
+- CI runs astral's `ty` type checker as a non-blocking, informational step alongside mypy, so we can track it while it matures (it stays in preview and does not gate merges).
 
 ### Fixed
 - The README logo now uses an absolute CDN URL so it renders on the PyPI project page (relative paths only resolve on GitHub).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ rename the headers to emoji form when cutting a release.
 - Raised the Rust extension's abi3 floor to `abi3-py310` to match the new Python minimum.
 - CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8.2.0, codecov v5 with token upload, action-gh-release v2).
 - `make test` now runs the Rust unit tests (`cargo test`) as part of the local CI-equivalent suite; previously they ran only in CI.
-- Both CI and `make test` run astral's `ty` type checker as a non-blocking, informational step alongside mypy, so we can track it while it matures (it stays in preview and does not gate the suite).
+- Added a `make typecheck-ty` command to run astral's `ty` type checker on demand (a 0.0.x preview, advisory only). mypy remains the enforced gate; ty is kept out of `make test` and is commented out in CI with a note to revisit once it stabilizes.
 
 ### Fixed
 - The README logo now uses an absolute CDN URL so it renders on the PyPI project page (relative paths only resolve on GitHub).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ rename the headers to emoji form when cutting a release.
 - **Breaking:** Dropped support for Python 3.8 and 3.9 (both end-of-life). The new minimum is Python 3.10 (`requires-python = ">=3.10,<3.16"`), which also lets the chain validators rely on stdlib chain-retrieval APIs unconditionally.
 - Modernized the codebase to Python 3.10+ idioms: built-in generics (`list`/`dict`), `X | None` unions, and a full ruff `pyupgrade` (UP) sweep, with `target-version = "py310"` enforcing it going forward. No runtime behavior change.
 - Raised the Rust extension's abi3 floor to `abi3-py310` to match the new Python minimum.
-- CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8, codecov v5 with token upload, action-gh-release v2).
+- CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8.2.0, codecov v5 with token upload, action-gh-release v2).
 - `make test` now runs the Rust unit tests (`cargo test`) as part of the local CI-equivalent suite; previously they ran only in CI.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ rename the headers to emoji form when cutting a release.
 - Modernized the codebase to Python 3.10+ idioms: built-in generics (`list`/`dict`), `X | None` unions, and a full ruff `pyupgrade` (UP) sweep, with `target-version = "py310"` enforcing it going forward. No runtime behavior change.
 - Raised the Rust extension's abi3 floor to `abi3-py310` to match the new Python minimum.
 - CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8, codecov v5 with token upload, action-gh-release v2).
+- `make test` now runs the Rust unit tests (`cargo test`) as part of the local CI-equivalent suite; previously they ran only in CI.
 
 ### Fixed
 - The README logo now uses an absolute CDN URL so it renders on the PyPI project page (relative paths only resolve on GitHub).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ rename the headers to emoji form when cutting a release.
 - Raised the Rust extension's abi3 floor to `abi3-py310` to match the new Python minimum.
 - CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8.2.0, codecov v5 with token upload, action-gh-release v2).
 - `make test` now runs the Rust unit tests (`cargo test`) as part of the local CI-equivalent suite; previously they ran only in CI.
-- CI runs astral's `ty` type checker as a non-blocking, informational step alongside mypy, so we can track it while it matures (it stays in preview and does not gate merges).
+- Both CI and `make test` run astral's `ty` type checker as a non-blocking, informational step alongside mypy, so we can track it while it matures (it stays in preview and does not gate the suite).
 
 ### Fixed
 - The README logo now uses an absolute CDN URL so it renders on the PyPI project page (relative paths only resolve on GitHub).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,17 @@ rename the headers to emoji form when cutting a release.
 ## [Unreleased]
 
 ### Added
-- TBD
+- Python 3.14 support, now part of the CI test matrix.
+- Python 3.15 pre-release support: CI exercises 3.15 betas via `allow-prereleases` so the package is ready ahead of the final release.
 
 ### Changed
-- TBD
+- **Breaking:** Dropped support for Python 3.8 and 3.9 (both end-of-life). The new minimum is Python 3.10 (`requires-python = ">=3.10,<3.16"`), which also lets the chain validators rely on stdlib chain-retrieval APIs unconditionally.
+- Modernized the codebase to Python 3.10+ idioms: built-in generics (`list`/`dict`), `X | None` unions, and a full ruff `pyupgrade` (UP) sweep, with `target-version = "py310"` enforcing it going forward. No runtime behavior change.
+- Raised the Rust extension's abi3 floor to `abi3-py310` to match the new Python minimum.
+- CI: the test matrix is now Python 3.10 through 3.15, and the GitHub Actions were refreshed (checkout v6, setup-python v6, setup-uv v8, codecov v5 with token upload, action-gh-release v2).
 
 ### Fixed
-- TBD
+- The README logo now uses an absolute CDN URL so it renders on the PyPI project page (relative paths only resolve on GitHub).
 
 ## [0.4.0] - 2026-06-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ python = ["dep:pyo3"]
 # parser to CertMonitor. Beyond pyo3 the crate has zero third-party
 # dependencies; the X.509 / DER parser under rust_certinfo/src/{der,x509}/
 # is implemented entirely against the Rust standard library.
-pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"], optional = true }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"], optional = true }
 

--- a/MODULARIZATION_REPORT.md
+++ b/MODULARIZATION_REPORT.md
@@ -4,14 +4,14 @@
 
 ### Test Modularization Status
 - **Modular test files:** 8 files
-- **Total test lines:** 2,127 lines
-- **Average file size:** 265 lines
+- **Total test lines:** 2,129 lines
+- **Average file size:** 266 lines
 - **Main test file:** 22 lines
 
 ### Test Coverage
 - **Overall coverage:** 98.7%
 - **Total tests:** 536
-- **Statements covered:** 1,207/1,223
+- **Statements covered:** 1,210/1,226
 - **Files with coverage:** 27
 
 ### Type Hint Coverage
@@ -30,7 +30,7 @@
 - **Python security scanning:** ✅ Enabled
 - **Python security issues found:** 0
 - **Files scanned by bandit:** 27
-- **Lines scanned by bandit:** 3,053
+- **Lines scanned by bandit:** 3,047
 - **Overall security status:** 🔒 Clean
 - **PyO3 version:** 0.29
 
@@ -46,13 +46,13 @@
 ## 🏗️ Test File Organization
 
 ### Modular Test Files
-- **test_certificate_operations.py**: 507 lines, 26 functions
+- **test_certificate_operations.py**: 510 lines, 26 functions
 - **test_validation.py**: 513 lines, 22 functions
 - **test_public_key_operations.py**: 211 lines, 12 functions
 - **test_initialization.py**: 209 lines, 17 functions
 - **test_raw_data_operations.py**: 70 lines, 4 functions
 - **test_utility_methods.py**: 139 lines, 11 functions
-- **test_connection_management.py**: 315 lines, 20 functions
+- **test_connection_management.py**: 314 lines, 20 functions
 - **test_cipher_operations.py**: 163 lines, 9 functions
 
 ### Main Test File
@@ -64,26 +64,26 @@
 
 ### Files with Type Hints
 - **config.py**: ❌ (14 lines)
-- **core.py**: ✅ (894 lines)
+- **core.py**: ✅ (893 lines)
 - **error_handlers.py**: ✅ (29 lines)
-- **cipher_algorithms.py**: ✅ (108 lines)
-- **protocol_handlers/ssl_handler.py**: ✅ (230 lines)
+- **cipher_algorithms.py**: ✅ (109 lines)
+- **protocol_handlers/ssl_handler.py**: ✅ (229 lines)
 - **protocol_handlers/ssh_handler.py**: ✅ (77 lines)
 - **protocol_handlers/base.py**: ✅ (28 lines)
 - **utils/utils.py**: ❌ (1 lines)
 - **validators/weak_cipher.py**: ✅ (115 lines)
 - **validators/pq_chain.py**: ✅ (199 lines)
-- **validators/sensitive_date.py**: ✅ (220 lines)
+- **validators/sensitive_date.py**: ✅ (215 lines)
 - **validators/subject_alt_names.py**: ✅ (253 lines)
 - **validators/results.py**: ✅ (70 lines)
-- **validators/chain.py**: ✅ (313 lines)
+- **validators/chain.py**: ✅ (312 lines)
 - **validators/expiration.py**: ✅ (102 lines)
 - **validators/pq_key_exchange.py**: ✅ (157 lines)
 - **validators/root_certificate_validator.py**: ✅ (129 lines)
 - **validators/pq_signature.py**: ✅ (186 lines)
 - **validators/tls_version.py**: ✅ (95 lines)
 - **validators/key_info.py**: ✅ (204 lines)
-- **validators/base.py**: ✅ (156 lines)
+- **validators/base.py**: ✅ (157 lines)
 - **validators/hostname.py**: ✅ (156 lines)
 - **validators/_utils.py**: ✅ (23 lines)
 

--- a/MODULARIZATION_REPORT.md
+++ b/MODULARIZATION_REPORT.md
@@ -39,7 +39,7 @@
 - **Unified commands:** 5 (format, lint, test)
 - **Language-specific:** 5 (python-*, rust-*)
 - **Security commands:** 1 (security, audit)
-- **CI-equivalent testing:** ✅ 9-step process
+- **CI-equivalent testing:** ✅ 10-step process
 
 ---
 
@@ -115,9 +115,9 @@
 
 
 ### CI-Equivalent Testing
-- **Test workflow steps:** 9/9
+- **Test workflow steps:** 10
 - **CI-equivalent testing:** ✅ Yes
-- **Workflow status:** 🚀 Full 9-step testing process available
+- **Workflow status:** 🚀 Full 10-step testing process available
 
 
 ### Development Commands
@@ -153,7 +153,7 @@ make report
 ### Enhanced Development Commands
 ```bash
 # 🚀 Recommended CI-equivalent workflow
-make test          # Full 9-step test suite (format, lint, typecheck, test, build)
+make test          # Full CI-equivalent test suite (format, lint, typecheck, test, build)
 make check         # Quick quality checks (format + lint)
 make develop       # Install for development
 

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,10 @@ test: develop
 	uv run mypy certmonitor/
 	@echo "✅ Type checking complete"
 	@echo ""
+	@echo "🔎 Type checking with ty (advisory, non-blocking, preview)..."
+	-uvx ty check certmonitor/
+	@echo "ℹ️  ty is informational only and does not gate this suite"
+	@echo ""
 	@echo "🔒 8/10 Security vulnerability check (Rust)..."
 	cargo audit
 	@echo "✅ Rust security audit complete"

--- a/Makefile
+++ b/Makefile
@@ -101,42 +101,46 @@ test: develop
 	@echo "🧪 Running comprehensive test suite (CI equivalent)..."
 	@echo "==================================================="
 	@echo ""
-	@echo "📋 1/9 Python code formatting check..."
+	@echo "📋 1/10 Python code formatting check..."
 	uv run ruff format --check .
 	@echo "✅ Python formatting check complete"
 	@echo ""
-	@echo "🔍 2/9 Python linting check..."
+	@echo "🔍 2/10 Python linting check..."
 	uv run ruff check .
 	@echo "✅ Python linting check complete"
 	@echo ""
-	@echo "🦀 3/9 Rust code formatting check..."
+	@echo "🦀 3/10 Rust code formatting check..."
 	cargo fmt --all -- --check
 	@echo "✅ Rust formatting check complete"
 	@echo ""
-	@echo "🔧 4/9 Rust linting check..."
+	@echo "🔧 4/10 Rust linting check..."
 	cargo clippy --all-targets --all-features -- -D warnings
 	@echo "✅ Rust linting check complete"
 	@echo ""
-	@echo "🧪 5/9 Running pytest with coverage..."
+	@echo "🦀 5/10 Rust unit tests..."
+	cargo test
+	@echo "✅ Rust tests complete"
+	@echo ""
+	@echo "🧪 6/10 Running pytest with coverage..."
 	uv run pytest --cov=certmonitor --cov-report=term-missing --cov-fail-under=95
 	@echo "✅ Tests and coverage complete"
 	@echo ""
-	@echo "🔧 6/9 Python type checking..."
+	@echo "🔧 7/10 Python type checking..."
 	uv run mypy certmonitor/
 	@echo "✅ Type checking complete"
 	@echo ""
-	@echo "🔒 7/9 Security vulnerability check (Rust)..."
+	@echo "🔒 8/10 Security vulnerability check (Rust)..."
 	cargo audit
 	@echo "✅ Rust security audit complete"
 	@echo ""
-	@echo "🛡️  8/9 Python security scanning..."
+	@echo "🛡️  9/10 Python security scanning..."
 	uv run bandit -r certmonitor/ -f json -o bandit-report.json -c .bandit
 	@echo "✅ Python security scan complete"
 	@echo ""
-	@echo "🏗️  9/9 Build verification..."
+	@echo "🏗️  10/10 Build verification..."
 	@$(MAKE) wheel >/dev/null 2>&1 && echo "✅ Build successful" || echo "❌ Build failed"
 	@echo ""
-	@echo "📊 10/10 Generating modularization report..."
+	@echo "📊 Generating modularization report..."
 	@python scripts/generate_report.py
 	@echo ""
 	@echo "🎉 All checks complete! Ready for PR/push."

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for certmonitor project
 
-.PHONY: develop build wheel test test-quick docs clean lint format format-check verify-wheel check report ci help typecheck python-lint python-format rust-format rust-format-check rust-lint security fuzz fuzz-long version version.patch version.minor version.major _sync-cargo-version
+.PHONY: develop build wheel test test-quick docs clean lint format format-check verify-wheel check report ci help typecheck typecheck-ty python-lint python-format rust-format rust-format-check rust-lint security fuzz fuzz-long version version.patch version.minor version.major _sync-cargo-version
 
 # Show available targets and their descriptions
 help:
@@ -24,6 +24,7 @@ help:
 	@echo "  rust-format  Run Rust-only formatting"
 	@echo "  rust-lint    Run Rust-only linting"
 	@echo "  typecheck    Run mypy type checking"
+	@echo "  typecheck-ty Run ty type checking (advisory preview, not gating)"
 	@echo "  security     Run security vulnerability check (Rust + Python)"
 	@echo "  ci           Alias for 'test' (full CI checks)"
 	@echo ""
@@ -129,10 +130,6 @@ test: develop
 	uv run mypy certmonitor/
 	@echo "✅ Type checking complete"
 	@echo ""
-	@echo "🔎 Type checking with ty (advisory, non-blocking, preview)..."
-	-uvx ty check certmonitor/
-	@echo "ℹ️  ty is informational only and does not gate this suite"
-	@echo ""
 	@echo "🔒 8/10 Security vulnerability check (Rust)..."
 	cargo audit
 	@echo "✅ Rust security audit complete"
@@ -157,6 +154,14 @@ check: lint format
 typecheck:
 	@echo "🔧 Running mypy type checking..."
 	uv run mypy certmonitor/
+
+# Advisory type check with astral's ty (currently a 0.0.x preview). mypy is the
+# enforced gate; this is informational only — run it when you want to see what
+# ty thinks. It is intentionally NOT part of 'make test'. Several diagnostics
+# are by-design (validator override signatures) or already suppressed for mypy.
+typecheck-ty:
+	@echo "🔎 Running ty type checking (advisory, preview)..."
+	-uvx ty check certmonitor/
 
 # Generate modularization and quality report
 report:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - ⚡ **High Performance:** Async- and batch-friendly. Designed for speed and concurrency.
 - 🧩 **Extensible:** Add your own custom validators for organization-specific checks.
 - 🔮 **Post-Quantum Readiness:** Opt-in validators detect post-quantum (hybrid/pure **ML-KEM**) TLS key exchange and post-quantum certificate keys/signatures (**ML-DSA**, **SLH-DSA**, composite), so you can track quantum-safe migration and *harvest-now-decrypt-later* exposure. See [below](#-post-quantum-readiness).
-- 🐍 **Native Python First:** Works out-of-the-box in any Python 3.8+ environment.
+- 🐍 **Native Python First:** Works out-of-the-box in any Python 3.10+ environment.
 - 🦀 **Rust-Powered Parsing:** Certificate parsing and public key extraction are handled by a Rust extension for speed, safety, and correctness. <strong>This is required for advanced public key and elliptic curve features, but all orchestration and logic are pure Python stdlib.</strong>
 - 📦 **Portable:** No system dependencies. Drop it into any project or CI pipeline.
 - 📝 **Comprehensive Docs:** [ReadTheDocs](https://certmonitor.readthedocs.io/) with usage, API, and advanced guides.
@@ -248,7 +248,7 @@ CertMonitor's certificate parser handles untrusted bytes from every TLS handshak
 - **Every parser path returns `Result`.** Malformed input produces a structured error, never a crash. No `.unwrap()` on user-input-derived data.
 - **2.8 billion fuzz iterations, zero crashes.** The parser is continuously fuzz-tested with [cargo-fuzz](https://github.com/rust-lang/cargo-fuzz) (libFuzzer) against adversarial byte sequences. A 1-hour soak run explores 310 code-coverage points and 505 libfuzzer features with zero panics. Run it yourself: `make fuzz`.
 - **130-cert real-world corpus on every CI run.** Every commit is tested against captured certificates from 101 production hosts spanning Google Trust Services, DigiCert, Let's Encrypt, Sectigo, Cloudflare, and more, covering both RSA and ECDSA key types.
-- **540+ Python tests at 99% line coverage, plus 99 Rust unit tests.** The full test suite runs across Python 3.8 to 3.13 and Rust stable on macOS, Ubuntu, and Windows.
+- **540+ Python tests at 99% line coverage, plus 99 Rust unit tests.** The full test suite runs across Python 3.10 to 3.15 and Rust stable on macOS, Ubuntu, and Windows.
 - **`cargo audit` on every PR.** CertMonitor declares a single direct Rust dependency, `pyo3` (the Python bridge). The whole compiled tree is 15 crates, all pyo3 and its helpers, with no third-party parsing crates, scanned for known vulnerabilities on every pull request.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://certmonitor.readthedocs.io/">
-    <img src="docs/images/logo.svg" alt="CertMonitor Logo" width="120" height="120">
+    <img src="https://cdn.jsdelivr.net/gh/bradh11/certmonitor@main/docs/images/logo.svg" alt="CertMonitor Logo" width="120" height="120">
   </a>
 </p>
 

--- a/certmonitor/certinfo.pyi
+++ b/certmonitor/certinfo.pyi
@@ -1,9 +1,9 @@
 # type: ignore
 """Stub file for certinfo Rust module to help with type checking."""
 
-from typing import Any, Dict, List
+from typing import Any
 
-def parse_public_key_info(der_bytes: bytes) -> Dict[str, Any]:
+def parse_public_key_info(der_bytes: bytes) -> dict[str, Any]:
     """Parse public key information from DER bytes."""
     ...
 
@@ -15,18 +15,18 @@ def extract_public_key_pem(der_bytes: bytes) -> str:
     """Extract public key in PEM format."""
     ...
 
-def analyze_chain(chain_ders: List[bytes]) -> Dict[str, Any]:
+def analyze_chain(chain_ders: list[bytes]) -> dict[str, Any]:
     """Analyze a certificate chain (list of DER certs)."""
     ...
 
-def pq_algorithms() -> List[Dict[str, Any]]:
+def pq_algorithms() -> list[dict[str, Any]]:
     """Return the post-quantum algorithm registry as
     [{"dotted": str, "name": str, "composite": bool}, ...]."""
     ...
 
 def probe_tls_handshake(
     host: str, port: int = 443, timeout_ms: int = 10000
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Probe a TLS 1.3 server's key-exchange group. Returns a dict in
     every terminal state:
       - {"result": "group", "id", "name", "kind", "is_pq", "protocol",

--- a/certmonitor/cipher_algorithms.py
+++ b/certmonitor/cipher_algorithms.py
@@ -2,7 +2,8 @@
 
 import re
 from functools import lru_cache
-from typing import Any, Dict, Pattern, Union, cast
+from typing import Any, cast
+from re import Pattern
 
 """
 This module defines the patterns for parsing a negotiated cipher suite
@@ -19,9 +20,9 @@ via validator arguments, rather than global state here.
 """
 
 # Type alias for the algorithms dictionary (can contain either strings or compiled patterns)
-AlgorithmDict = Dict[str, Union[str, Pattern[str]]]
+AlgorithmDict = dict[str, str | Pattern[str]]
 
-ALL_ALGORITHMS: Dict[str, AlgorithmDict] = {
+ALL_ALGORITHMS: dict[str, AlgorithmDict] = {
     "encryption": {
         "AES": r"AES",
         "CHACHA20": r"CHACHA20",
@@ -65,7 +66,7 @@ for category in ALL_ALGORITHMS.values():
 
 
 @lru_cache(maxsize=128)
-def parse_cipher_suite(cipher_suite: str) -> Dict[str, str]:
+def parse_cipher_suite(cipher_suite: str) -> dict[str, str]:
     """
     Parse a cipher suite string to identify encryption, key exchange, and MAC algorithms.
     """
@@ -82,7 +83,7 @@ def parse_cipher_suite(cipher_suite: str) -> Dict[str, str]:
     return result
 
 
-def list_algorithms() -> Dict[str, Any]:
+def list_algorithms() -> dict[str, Any]:
     """
     List all known algorithms by category.
     """
@@ -92,7 +93,7 @@ def list_algorithms() -> Dict[str, Any]:
     return alg_list
 
 
-def update_algorithms(custom_algorithms: Dict[str, Dict[str, str]]) -> None:
+def update_algorithms(custom_algorithms: dict[str, dict[str, str]]) -> None:
     """
     Update the ALL_ALGORITHMS dictionary with user-provided custom algorithms.
     """

--- a/certmonitor/core.py
+++ b/certmonitor/core.py
@@ -7,7 +7,8 @@ import socket
 import ssl
 import tempfile
 import warnings
-from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Union, cast, Tuple
+from typing import Any, cast
+from collections.abc import Mapping
 
 from certmonitor import certinfo, config
 from certmonitor.cipher_algorithms import parse_cipher_suite
@@ -25,7 +26,7 @@ class CertMonitor:
         self,
         host: str,
         port: int = 443,
-        enabled_validators: Optional[List[str]] = None,
+        enabled_validators: list[str] | None = None,
     ):
         """Initialize the CertMonitor with the specified host and port."""
         self.host = host
@@ -34,7 +35,7 @@ class CertMonitor:
         self.der = None
         self.pem = None
         self.cert_info = None
-        self.cert_data: Dict[str, Any] = {}
+        self.cert_data: dict[str, Any] = {}
         self.public_key_der = None
         self.public_key_pem = None
         self.validators = VALIDATORS
@@ -44,8 +45,8 @@ class CertMonitor:
             else config.ENABLED_VALIDATORS
         )
         self.error_handler = ErrorHandler()
-        self.handler: Optional[BaseProtocolHandler] = None
-        self.protocol: Optional[str] = None
+        self.handler: BaseProtocolHandler | None = None
+        self.protocol: str | None = None
         self.connected = False
 
     def __enter__(self) -> "CertMonitor":
@@ -57,7 +58,7 @@ class CertMonitor:
         """Exit the runtime context related to this object."""
         self.close()
 
-    def connect(self) -> Optional[Dict[str, Any]]:
+    def connect(self) -> dict[str, Any] | None:
         """Establishes a connection to the host if not already connected."""
         if self.connected:
             logging.debug("Already connected, skipping connection attempt")
@@ -76,7 +77,7 @@ class CertMonitor:
             self.handler = SSHHandler(self.host, self.port, self.error_handler)
         else:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ProtocolError",
                     f"Unsupported protocol: {self.protocol}",
@@ -99,7 +100,7 @@ class CertMonitor:
             self.handler.close()
         self.handler = None
 
-    def detect_protocol(self) -> Union[str, Dict[str, Any]]:
+    def detect_protocol(self) -> str | dict[str, Any]:
         """Detect the protocol used by the host."""
         try:
             with socket.create_connection((self.host, self.port), timeout=10) as sock:
@@ -112,7 +113,7 @@ class CertMonitor:
                         return "ssl"
                     else:
                         return cast(
-                            Dict[str, Any],
+                            dict[str, Any],
                             self.error_handler.handle_error(
                                 "ProtocolDetectionError",
                                 f"Unable to determine protocol. First bytes: {data.hex()}",
@@ -120,20 +121,20 @@ class CertMonitor:
                                 self.port,
                             ),
                         )
-                except socket.error:
+                except OSError:
                     # If no data is received, assume it's SSL
                     return "ssl"
                 finally:
                     sock.setblocking(True)
         except Exception as e:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ConnectionError", str(e), self.host, self.port
                 ),
             )
 
-    def _ensure_connection(self) -> Optional[Dict[str, Any]]:
+    def _ensure_connection(self) -> dict[str, Any] | None:
         """Ensures that a valid connection is established."""
         if not self.connected:
             connect_result = self.connect()
@@ -171,7 +172,7 @@ class CertMonitor:
         except ValueError:
             return False
 
-    def _fetch_raw_cert(self) -> Dict[str, Any]:
+    def _fetch_raw_cert(self) -> dict[str, Any]:
         """Fetches the raw certificate from the connected host."""
         connection_result = self._ensure_connection()
         if connection_result is not None:  # Connection failed
@@ -179,7 +180,7 @@ class CertMonitor:
 
         if self.handler is None:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ConnectionError",
                     "Handler is not initialized",
@@ -251,7 +252,7 @@ class CertMonitor:
             cert_data.setdefault("chain_analysis", None)
 
         # Leaf-only fallback: when the chain could not be retrieved
-        # (Python 3.8/3.9, or a chain fetch/parse failure) but the leaf
+        # (a chain fetch or parse failure, e.g. an unreachable issuer) but the leaf
         # DER is in hand, analyze just the leaf so leaf-scoped validators
         # (e.g. pq_signature, which needs the leaf's signature algorithm)
         # work on every interpreter instead of inheriting the chain's
@@ -272,7 +273,7 @@ class CertMonitor:
         self.cert_data = cert_data
         return cert_data
 
-    def _fetch_raw_cipher(self) -> Union[Tuple[str, str, int], Dict[str, Any]]:
+    def _fetch_raw_cipher(self) -> tuple[str, str, int] | dict[str, Any]:
         """Fetch the raw cipher information."""
         connection_result = self._ensure_connection()
         if connection_result is not None:  # Connection failed
@@ -280,7 +281,7 @@ class CertMonitor:
 
         if self.protocol != "ssl":
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ProtocolError",
                     "Cipher information is only available for SSL/TLS connections",
@@ -291,7 +292,7 @@ class CertMonitor:
 
         if self.handler is None:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ConnectionError",
                     "Handler is not initialized",
@@ -304,12 +305,12 @@ class CertMonitor:
         if hasattr(self.handler, "fetch_raw_cipher"):
             # We know the handler has fetch_raw_cipher, so we can use Any to bypass type checking
             return cast(
-                Union[Tuple[str, str, int], Dict[str, Any]],
+                tuple[str, str, int] | dict[str, Any],
                 cast(Any, self.handler).fetch_raw_cipher(),
             )
         else:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ProtocolError",
                     "fetch_raw_cipher not available for this handler type",
@@ -318,7 +319,7 @@ class CertMonitor:
                 ),
             )
 
-    def _parse_pem_cert(self, pem_cert: str) -> Dict[str, Any]:
+    def _parse_pem_cert(self, pem_cert: str) -> dict[str, Any]:
         """Parse a PEM formatted certificate to extract relevant details."""
         with tempfile.NamedTemporaryFile(delete=False, mode="w") as temp_file:
             temp_file.write(pem_cert)
@@ -337,7 +338,7 @@ class CertMonitor:
             os.remove(temp_file_path)
 
         # Ensure we return a Dict[str, Any]
-        return cast(Dict[str, Any], cert_details)
+        return cast(dict[str, Any], cert_details)
 
     def _to_structured_dict(self, data: Any) -> Any:
         """Convert the certificate data into a structured dictionary format.
@@ -349,8 +350,8 @@ class CertMonitor:
             dict: A dictionary containing the structured certificate data.
         """
 
-        def _handle_duplicate_keys(data: Any) -> Dict[str, Any]:
-            result: Dict[str, Any] = {}
+        def _handle_duplicate_keys(data: Any) -> dict[str, Any]:
+            result: dict[str, Any] = {}
             for item in data:
                 if isinstance(item, tuple) and len(item) == 2:
                     key, value = item
@@ -379,7 +380,7 @@ class CertMonitor:
         else:
             return data
 
-    def get_cert_info(self) -> Dict[str, Any]:
+    def get_cert_info(self) -> dict[str, Any]:
         """Retrieves and structures the certificate details."""
         if not self.cert_info:
             try:
@@ -404,7 +405,7 @@ class CertMonitor:
             except Exception as e:
                 logging.error(f"Error while getting certificate info: {e}")
                 return cast(
-                    Dict[str, Any],
+                    dict[str, Any],
                     self.error_handler.handle_error(
                         "UnknownError", str(e), self.host, self.port
                     ),
@@ -412,11 +413,11 @@ class CertMonitor:
 
         return self.cert_info if self.cert_info is not None else {}
 
-    def get_raw_der(self) -> Union[bytes, Dict[str, Any]]:
+    def get_raw_der(self) -> bytes | dict[str, Any]:
         """Return the raw DER format of the certificate."""
         if self.protocol != "ssl":
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ProtocolError",
                     "DER format is only available for SSL/TLS connections",
@@ -432,7 +433,7 @@ class CertMonitor:
         if self.der is None:
             if self.handler is None:
                 return cast(
-                    Dict[str, Any],
+                    dict[str, Any],
                     self.error_handler.handle_error(
                         "ConnectionError",
                         "Handler is not initialized",
@@ -449,11 +450,11 @@ class CertMonitor:
         # Return the DER or empty bytes if None
         return self.der if self.der is not None else b""
 
-    def get_raw_pem(self) -> Union[str, Dict[str, Any]]:
+    def get_raw_pem(self) -> str | dict[str, Any]:
         """Return the raw PEM format of the certificate."""
         if self.protocol != "ssl":
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ProtocolError",
                     "PEM format is only available for SSL/TLS connections",
@@ -469,7 +470,7 @@ class CertMonitor:
         if self.pem is None:
             if self.handler is None:
                 return cast(
-                    Dict[str, Any],
+                    dict[str, Any],
                     self.error_handler.handle_error(
                         "ConnectionError",
                         "Handler is not initialized",
@@ -486,7 +487,7 @@ class CertMonitor:
         # Return the PEM or empty string if None
         return self.pem if self.pem is not None else ""
 
-    def get_public_key_der(self) -> Union[bytes, Dict[str, Any], None]:
+    def get_public_key_der(self) -> bytes | dict[str, Any] | None:
         """Return the public key in DER format."""
         if self.protocol != "ssl":
             return self.error_handler.handle_error(
@@ -508,7 +509,7 @@ class CertMonitor:
 
         return self.public_key_der
 
-    def get_public_key_pem(self) -> Union[str, Dict[str, Any], None]:
+    def get_public_key_pem(self) -> str | dict[str, Any] | None:
         """Return the public key in PEM format."""
         if self.protocol != "ssl":
             return self.error_handler.handle_error(
@@ -530,7 +531,7 @@ class CertMonitor:
 
         return self.public_key_pem
 
-    def get_cipher_info(self) -> Dict[str, Any]:
+    def get_cipher_info(self) -> dict[str, Any]:
         """Retrieve and structure the cipher information of the SSL/TLS connection."""
         raw_cipher = self._fetch_raw_cipher()
 
@@ -545,9 +546,9 @@ class CertMonitor:
             )
 
         cipher_suite, protocol_version, key_bit_length = raw_cipher
-        parsed_cipher: Dict[str, str] = parse_cipher_suite(cipher_suite)
+        parsed_cipher: dict[str, str] = parse_cipher_suite(cipher_suite)
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "cipher_suite": {
                 "name": cipher_suite,
                 "encryption_algorithm": parsed_cipher["encryption"],
@@ -568,9 +569,7 @@ class CertMonitor:
 
         return result
 
-    def validate(
-        self, validator_args: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+    def validate(self, validator_args: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Validates the target host by running all enabled validators.
 
@@ -596,7 +595,7 @@ class CertMonitor:
             print(results["expiration"])      # Output for expiration validator
             print(results["weak_cipher"])     # Output for weak cipher validator
         """
-        results: Dict[str, Any] = {}
+        results: dict[str, Any] = {}
 
         # Check for unknown validators
         for requested_validator in self.enabled_validators:
@@ -617,7 +616,7 @@ class CertMonitor:
         # Each named data source is fetched at most once per call and
         # shared across every validator that requires it (e.g. cipher_info
         # and a future tls_probe).
-        source_cache: Dict[str, Any] = {}
+        source_cache: dict[str, Any] = {}
 
         def resolve_source(source_name: str) -> Any:
             if source_name not in source_cache:
@@ -633,8 +632,8 @@ class CertMonitor:
                 vtype = getattr(validator, "validator_type", "cert")
                 requires = ("cipher_info",) if vtype == "cipher" else ("cert_data",)
 
-            resolved: List[Any] = []
-            source_error: Optional[Dict[str, Any]] = None
+            resolved: list[Any] = []
+            source_error: dict[str, Any] | None = None
             for source_name in requires:
                 value = resolve_source(source_name)
                 source_error = self._source_error(source_name, value)
@@ -674,7 +673,7 @@ class CertMonitor:
             "message": f"No fetcher registered for data source {source_name!r}.",
         }
 
-    def _fetch_tls_probe(self) -> Dict[str, Any]:
+    def _fetch_tls_probe(self) -> dict[str, Any]:
         """Probe the negotiated TLS 1.3 key-exchange group via the Rust probe.
 
         Skip-for-legacy short-circuit: the *primary* connection has already
@@ -707,7 +706,7 @@ class CertMonitor:
             }
         try:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 certinfo.probe_tls_handshake(self.host, self.port),  # type: ignore[attr-defined]
             )
         except Exception as exc:  # noqa: BLE001 — never let the probe raise into dispatch
@@ -717,7 +716,7 @@ class CertMonitor:
                 "message": f"TLS probe failed: {exc}",
             }
 
-    def _source_error(self, source_name: str, value: Any) -> Optional[Dict[str, Any]]:
+    def _source_error(self, source_name: str, value: Any) -> dict[str, Any] | None:
         """Return a structured error result if ``value`` is unusable.
 
         Returns ``None`` when the source is good. The messages preserve the
@@ -751,9 +750,9 @@ class CertMonitor:
     def _invoke_validator(
         self,
         validator: Any,
-        framework_args: Tuple[Any, ...],
-        validator_args: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        framework_args: tuple[Any, ...],
+        validator_args: dict[str, Any] | None,
+    ) -> dict[str, Any]:
         """Resolve user kwargs from ``validator_args`` and call ``validator.validate``.
 
         Looks up the validator's cached ``_user_param_names`` (built at class
@@ -774,7 +773,7 @@ class CertMonitor:
             # a bare list of alternate names. Map a bare list to the validator's
             # single user param if (and only if) it has exactly one. Emit a
             # ``DeprecationWarning`` so callers can migrate to the named form.
-            user_param_names: FrozenSet[str] = getattr(
+            user_param_names: frozenset[str] = getattr(
                 validator, "_user_param_names", frozenset()
             )
             if isinstance(raw, list) and len(user_param_names) == 1:
@@ -810,14 +809,14 @@ class CertMonitor:
             }
 
         try:
-            return cast(Dict[str, Any], validator.validate(*framework_args, **kwargs))
+            return cast(dict[str, Any], validator.validate(*framework_args, **kwargs))
         except TypeError as exc:
             return {
                 "is_valid": False,
                 "reason": f"Validator {validator.name!r} rejected args: {exc}",
             }
 
-    def get_enabled_validators(self) -> List[str]:
+    def get_enabled_validators(self) -> list[str]:
         """
         Get the list of validators enabled for this CertMonitor instance.
 
@@ -828,7 +827,7 @@ class CertMonitor:
             self.enabled_validators.copy()
         )  # Return a copy to prevent external modification
 
-    def list_validators(self) -> List[str]:
+    def list_validators(self) -> list[str]:
         """
         Get a list of all available validators that can be used.
 
@@ -839,7 +838,7 @@ class CertMonitor:
 
         return _list_validators()
 
-    def describe_validators(self) -> Dict[str, Dict[str, Any]]:
+    def describe_validators(self) -> dict[str, dict[str, Any]]:
         """Describe every registered validator and the user args it accepts.
 
         Reads each validator's cached ``_user_params`` (built by
@@ -866,10 +865,10 @@ class CertMonitor:
         """
         import inspect
 
-        described: Dict[str, Dict[str, Any]] = {}
+        described: dict[str, dict[str, Any]] = {}
         for name, validator in self.validators.items():
             user_params = getattr(validator, "_user_params", {}) or {}
-            args_info: Dict[str, Dict[str, Any]] = {}
+            args_info: dict[str, dict[str, Any]] = {}
             for param_name, param in user_params.items():
                 # ``str()`` renders both plain classes and parameterized
                 # generics; only plain classes need the ``<class 'X'>`` wrapper

--- a/certmonitor/protocol_handlers/base.py
+++ b/certmonitor/protocol_handlers/base.py
@@ -3,23 +3,23 @@
 import socket
 import ssl
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class BaseProtocolHandler(ABC):
     def __init__(self, host: str, port: int, error_handler: Any) -> None:
         self.host = host
         self.port = port
-        self.socket: Optional[socket.socket] = None
-        self.secure_socket: Optional[ssl.SSLSocket] = None
+        self.socket: socket.socket | None = None
+        self.secure_socket: ssl.SSLSocket | None = None
         self.error_handler = error_handler
 
     @abstractmethod
-    def connect(self) -> Optional[Dict[str, Any]]:
+    def connect(self) -> dict[str, Any] | None:
         pass
 
     @abstractmethod
-    def fetch_raw_cert(self) -> Dict[str, Any]:
+    def fetch_raw_cert(self) -> dict[str, Any]:
         pass
 
     @abstractmethod

--- a/certmonitor/protocol_handlers/ssh_handler.py
+++ b/certmonitor/protocol_handlers/ssh_handler.py
@@ -2,36 +2,36 @@
 
 import re
 import socket
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 from .base import BaseProtocolHandler
 
 
 class SSHHandler(BaseProtocolHandler):
-    def connect(self) -> Optional[Dict[str, Any]]:
+    def connect(self) -> dict[str, Any] | None:
         try:
             self.socket = socket.create_connection((self.host, self.port), timeout=10)
             return None
-        except socket.error as e:
+        except OSError as e:
             return cast(
-                Optional[Dict[str, Any]],
+                dict[str, Any] | None,
                 self.error_handler.handle_error(
                     "SocketError", str(e), self.host, self.port
                 ),
             )
         except Exception as e:
             return cast(
-                Optional[Dict[str, Any]],
+                dict[str, Any] | None,
                 self.error_handler.handle_error(
                     "UnknownError", str(e), self.host, self.port
                 ),
             )
 
-    def fetch_raw_cert(self) -> Dict[str, Any]:
+    def fetch_raw_cert(self) -> dict[str, Any]:
         try:
             if not self.socket:
                 return cast(
-                    Dict[str, Any],
+                    dict[str, Any],
                     self.error_handler.handle_error(
                         "ConnectionError", "Socket not connected", self.host, self.port
                     ),
@@ -48,14 +48,14 @@ class SSHHandler(BaseProtocolHandler):
                 }
             else:
                 return cast(
-                    Dict[str, Any],
+                    dict[str, Any],
                     self.error_handler.handle_error(
                         "SSHError", "Invalid SSH banner", self.host, self.port
                     ),
                 )
         except Exception as e:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "SSHError", str(e), self.host, self.port
                 ),
@@ -72,5 +72,5 @@ class SSHHandler(BaseProtocolHandler):
         try:
             self.socket.getpeername()
             return True
-        except socket.error:
+        except OSError:
             return False

--- a/certmonitor/protocol_handlers/ssl_handler.py
+++ b/certmonitor/protocol_handlers/ssl_handler.py
@@ -4,7 +4,7 @@ import logging
 import socket
 import ssl
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, cast
 
 from .base import BaseProtocolHandler
 
@@ -12,12 +12,12 @@ from .base import BaseProtocolHandler
 class SSLHandler(BaseProtocolHandler):
     def __init__(self, host: str, port: int, error_handler: Any) -> None:
         super().__init__(host, port, error_handler)
-        self.socket: Optional[socket.socket] = None
-        self.secure_socket: Optional[ssl.SSLSocket] = None
-        self.tls_version: Optional[str] = None
+        self.socket: socket.socket | None = None
+        self.secure_socket: ssl.SSLSocket | None = None
+        self.tls_version: str | None = None
 
-    def get_supported_protocols(self) -> List[int]:
-        supported_protocols: List[int] = []
+    def get_supported_protocols(self) -> list[int]:
+        supported_protocols: list[int] = []
         # NOTE: Legacy TLS/SSL versions are intentionally included for security assessment
         # This tool needs to detect and analyze weak configurations in legacy systems
         for protocol in [
@@ -36,7 +36,7 @@ class SSLHandler(BaseProtocolHandler):
                 pass
         return supported_protocols
 
-    def connect(self) -> Optional[Dict[str, Any]]:
+    def connect(self) -> dict[str, Any] | None:
         protocols = self.get_supported_protocols()
         for protocol in protocols:
             try:
@@ -91,7 +91,7 @@ class SSLHandler(BaseProtocolHandler):
 
         # If all protocols fail
         return cast(
-            Dict[str, Any],
+            dict[str, Any],
             self.error_handler.handle_error(
                 "SSLError",
                 "Failed to establish SSL connection with any protocol",
@@ -100,10 +100,10 @@ class SSLHandler(BaseProtocolHandler):
             ),
         )
 
-    def fetch_raw_cert(self) -> Dict[str, Any]:
+    def fetch_raw_cert(self) -> dict[str, Any]:
         if not self.secure_socket:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ConnectionError",
                     "SSL connection not established",
@@ -115,7 +115,7 @@ class SSLHandler(BaseProtocolHandler):
             cert = self.secure_socket.getpeercert(binary_form=True)
             if cert is None:
                 return cast(
-                    Dict[str, Any],
+                    dict[str, Any],
                     self.error_handler.handle_error(
                         "CertificateError",
                         "No certificate available",
@@ -133,22 +133,21 @@ class SSLHandler(BaseProtocolHandler):
             }
         except Exception as e:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "CertificateError", str(e), self.host, self.port
                 ),
             )
 
-    def _fetch_chain_der(self) -> Tuple[Optional[List[bytes]], Optional[str]]:
+    def _fetch_chain_der(self) -> tuple[list[bytes] | None, str | None]:
         """Retrieve the peer certificate chain as a list of DER byte strings.
 
         Python 3.13 exposes ``SSLSocket.get_verified_chain()``, which returns
         DER bytes directly. Python 3.10–3.12 only exposes the chain through
         the private ``_sslobj`` attribute as ``_ssl.Certificate`` instances,
         so we pull those, ask each for its PEM, and convert back to DER using
-        the public ``ssl.PEM_cert_to_DER_cert`` helper. On 3.8/3.9 there is
-        no stdlib-only way to obtain the chain and we return an informative
-        error instead.
+        the public ``ssl.PEM_cert_to_DER_cert`` helper. If neither API is
+        available, an informative error is returned.
         """
         if not self.secure_socket:
             return None, "SSL connection not established"
@@ -169,14 +168,14 @@ class SSLHandler(BaseProtocolHandler):
                 return None, f"Failed to retrieve certificate chain: {exc}"
 
         return None, (
-            "Certificate chain retrieval requires Python 3.10 or newer; "
-            "on this interpreter only the leaf certificate is available."
+            "Certificate chain retrieval is not available on this interpreter; "
+            "only the leaf certificate could be obtained."
         )
 
-    def fetch_raw_cipher(self) -> Union[Tuple[str, str, Optional[int]], Dict[str, Any]]:
+    def fetch_raw_cipher(self) -> tuple[str, str, int | None] | dict[str, Any]:
         if not self.secure_socket:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "ConnectionError",
                     "SSL connection not established",
@@ -187,7 +186,7 @@ class SSLHandler(BaseProtocolHandler):
         cipher_info = self.secure_socket.cipher()
         if cipher_info is None:
             return cast(
-                Dict[str, Any],
+                dict[str, Any],
                 self.error_handler.handle_error(
                     "CipherError",
                     "No cipher information available",
@@ -200,7 +199,7 @@ class SSLHandler(BaseProtocolHandler):
             return cipher_info
         # This should not happen in practice, but we handle it defensively
         return cast(  # type: ignore[unreachable]
-            Dict[str, Any],
+            dict[str, Any],
             self.error_handler.handle_error(
                 "CipherError", "Cipher information is not a tuple", self.host, self.port
             ),

--- a/certmonitor/validators/_utils.py
+++ b/certmonitor/validators/_utils.py
@@ -6,12 +6,12 @@ These are package-private (leading underscore) and not part of the public API.
 """
 
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
 _NOT_AFTER_FORMAT = "%b %d %H:%M:%S %Y GMT"
 
 
-def parse_not_after(cert: Dict[str, Any]) -> datetime:
+def parse_not_after(cert: dict[str, Any]) -> datetime:
     """Parse the ``notAfter`` field from a validator's ``cert`` argument.
 
     Centralizes the format string so that any future change to how certmonitor

--- a/certmonitor/validators/base.py
+++ b/certmonitor/validators/base.py
@@ -16,7 +16,8 @@ discovered user parameters, and exposes them for dispatch and introspection.
 
 import inspect
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, FrozenSet, Mapping, Tuple
+from typing import Any, ClassVar
+from collections.abc import Mapping
 
 
 class BaseValidator(ABC):
@@ -53,10 +54,10 @@ class _ValidatorBase(BaseValidator):
     """
 
     # Ordered data sources the dispatcher injects (see the class docstring).
-    requires: ClassVar[Tuple[str, ...]] = ()
+    requires: ClassVar[tuple[str, ...]] = ()
     _framework_arity: ClassVar[int] = 0
     _user_params: ClassVar[Mapping[str, inspect.Parameter]] = {}
-    _user_param_names: ClassVar[FrozenSet[str]] = frozenset()
+    _user_param_names: ClassVar[frozenset[str]] = frozenset()
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -75,7 +76,7 @@ class _ValidatorBase(BaseValidator):
         # its sources, never a separate count.
         arity = len(cls.requires) + 2
         cls._framework_arity = arity
-        user_params: Dict[str, inspect.Parameter] = {}
+        user_params: dict[str, inspect.Parameter] = {}
         problems = []
         positional_seen = 0
 
@@ -133,10 +134,10 @@ class BaseCertValidator(_ValidatorBase):
     """Base class for validators that inspect parsed certificate data."""
 
     validator_type: str = "cert"
-    requires: ClassVar[Tuple[str, ...]] = ("cert_data",)
+    requires: ClassVar[tuple[str, ...]] = ("cert_data",)
 
     def validate(
-        self, cert_info: Dict[str, Any], host: str, port: int
+        self, cert_info: dict[str, Any], host: str, port: int
     ) -> Mapping[str, Any]:
         # Default implementation — subclasses override.
         return None  # type: ignore[return-value]
@@ -146,10 +147,10 @@ class BaseCipherValidator(_ValidatorBase):
     """Base class for validators that inspect negotiated cipher suite data."""
 
     validator_type: str = "cipher"
-    requires: ClassVar[Tuple[str, ...]] = ("cipher_info",)
+    requires: ClassVar[tuple[str, ...]] = ("cipher_info",)
 
     def validate(
-        self, cipher_info: Dict[str, Any], host: str, port: int
+        self, cipher_info: dict[str, Any], host: str, port: int
     ) -> Mapping[str, Any]:
         # Default implementation — subclasses override.
         return None  # type: ignore[return-value]

--- a/certmonitor/validators/chain.py
+++ b/certmonitor/validators/chain.py
@@ -1,7 +1,7 @@
 # validators/chain.py
 
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from .base import BaseCertValidator
 from .results import ValidationResult
@@ -13,7 +13,7 @@ class ChainResult(ValidationResult, total=False):
     chain_length: int
     chain_ordered: bool
     terminates_in_self_signed: bool
-    certs: List[Dict[str, Any]]
+    certs: list[dict[str, Any]]
 
 
 # Signature algorithm OIDs treated as weak by default. Override per-call via
@@ -29,7 +29,7 @@ _DEFAULT_WEAK_SIG_OIDS: frozenset = frozenset(
 )
 
 
-def _format_dn(fields: Dict[str, Any]) -> str:
+def _format_dn(fields: dict[str, Any]) -> str:
     cn = fields.get("commonName")
     o = fields.get("organizationName")
     if cn and o:
@@ -49,9 +49,9 @@ class ChainValidator(BaseCertValidator):
     handshake (leaf through root) and checks for the problems operators
     actually hit in production: missing intermediates, out-of-order chains,
     expired members, weak signature algorithms, and non-CA intermediates.
-    It does **not** perform cryptographic signature verification — that is
-    intentionally left to Phase 2 to keep the Rust dependency footprint at
-    ``pyo3 + x509-parser``.
+    It does **not** perform cryptographic signature verification; that is
+    intentionally left to a future iteration to keep the Rust dependency
+    footprint minimal (the in-tree parser, no third-party crates).
 
     The validator ships **disabled by default**. Opt in via:
 
@@ -61,8 +61,8 @@ class ChainValidator(BaseCertValidator):
 
     or by setting ``ENABLED_VALIDATORS`` in the environment.
 
-    Chain retrieval requires Python 3.10 or newer. On 3.8/3.9 this validator
-    reports a clear error rather than silently degrading.
+    Chain retrieval uses stdlib APIs available on all supported Python
+    versions (3.10+).
 
     Attributes:
         name (str): The name of the validator.
@@ -72,14 +72,14 @@ class ChainValidator(BaseCertValidator):
 
     def validate(
         self,
-        cert: Dict[str, Any],
+        cert: dict[str, Any],
         host: str,
         port: int,
         *,
         min_chain_length: int = 2,
         require_root_in_chain: bool = False,
         allow_self_signed_leaf: bool = False,
-        weak_signature_algorithms: Optional[List[str]] = None,
+        weak_signature_algorithms: list[str] | None = None,
     ) -> ChainResult:
         """
         Validate the certificate chain fetched alongside the leaf cert.
@@ -109,7 +109,7 @@ class ChainValidator(BaseCertValidator):
                 The shape is stable and documented in
                 ``docs/validators/chain.md``.
         """
-        warnings: List[str] = []
+        warnings: list[str] = []
 
         chain_error = cert.get("chain_error")
         if chain_error:
@@ -127,8 +127,7 @@ class ChainValidator(BaseCertValidator):
         if analysis is None:
             reason = (
                 "Certificate chain was not fetched. This typically means the "
-                "Python interpreter is older than 3.10 or the SSL handler did "
-                "not populate the chain."
+                "SSL handler did not populate the chain."
             )
             return {
                 "is_valid": False,
@@ -160,15 +159,15 @@ class ChainValidator(BaseCertValidator):
         chain_length: int = analysis["chain_length"]
         chain_ordered: bool = analysis["ordered"]
         terminates_in_self_signed: bool = analysis["terminates_in_self_signed"]
-        raw_certs: List[Dict[str, Any]] = list(analysis.get("certs", []))
+        raw_certs: list[dict[str, Any]] = list(analysis.get("certs", []))
 
         now = datetime.datetime.now(datetime.timezone.utc)
         any_expired = False
         any_not_yet_valid = False
 
-        cert_reports: List[Dict[str, Any]] = []
+        cert_reports: list[dict[str, Any]] = []
         for idx, raw in enumerate(raw_certs):
-            cert_warnings: List[str] = []
+            cert_warnings: list[str] = []
 
             not_before_ts = raw["not_before_unix"]
             not_after_ts = raw["not_after_unix"]

--- a/certmonitor/validators/expiration.py
+++ b/certmonitor/validators/expiration.py
@@ -1,7 +1,7 @@
 # validators/expiration.py
 
 import datetime
-from typing import Any, Dict, List
+from typing import Any
 
 from ._utils import parse_not_after
 from .base import BaseCertValidator
@@ -25,7 +25,7 @@ class ExpirationValidator(BaseCertValidator):
 
     name: str = "expiration"
 
-    def validate(self, cert: Dict[str, Any], host: str, port: int) -> ExpirationResult:
+    def validate(self, cert: dict[str, Any], host: str, port: int) -> ExpirationResult:
         """
         Validates the expiration date of the provided SSL certificate.
 
@@ -66,14 +66,14 @@ class ExpirationValidator(BaseCertValidator):
                 }
                 ```
         """
-        # Use timezone.utc for Python 3.8+ compatibility
+        # Timezone-aware UTC so the comparison against notAfter is correct.
         now = datetime.datetime.now(datetime.timezone.utc)
         not_after = parse_not_after(cert).replace(tzinfo=datetime.timezone.utc)
 
         is_valid = now < not_after
         days_to_expiry = (not_after - now).days
 
-        warnings: List[str] = []
+        warnings: list[str] = []
         if days_to_expiry < 0:
             warnings.append(
                 f"Certificate is expired and has been expired for ({days_to_expiry} days)"

--- a/certmonitor/validators/hostname.py
+++ b/certmonitor/validators/hostname.py
@@ -1,6 +1,6 @@
 # validators/hostname.py
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from .base import BaseCertValidator
 from .results import ValidationResult
@@ -10,7 +10,7 @@ class HostnameResult(ValidationResult, total=False):
     """Result shape for :class:`HostnameValidator` (envelope + data)."""
 
     matched_name: str
-    alt_names: List[str]
+    alt_names: list[str]
 
 
 class HostnameValidator(BaseCertValidator):
@@ -23,7 +23,7 @@ class HostnameValidator(BaseCertValidator):
 
     name: str = "hostname"
 
-    def validate(self, cert: Dict[str, Any], host: str, port: int) -> HostnameResult:
+    def validate(self, cert: dict[str, Any], host: str, port: int) -> HostnameResult:
         """
         Validates the hostname against the Subject Alternative Names (SANs) and Common Name (CN) in the provided SSL certificate.
 
@@ -103,7 +103,7 @@ class HostnameValidator(BaseCertValidator):
             "alt_names": dns_names,
         }
 
-    def _get_common_name(self, cert: dict) -> Optional[str]:
+    def _get_common_name(self, cert: dict) -> str | None:
         """
         Retrieves the Common Name (CN) from the certificate.
 

--- a/certmonitor/validators/key_info.py
+++ b/certmonitor/validators/key_info.py
@@ -1,6 +1,6 @@
 # validators/key_info.py
 
-from typing import Any, Dict, FrozenSet, Optional
+from typing import Any
 
 from certmonitor import certinfo
 
@@ -12,7 +12,7 @@ class KeyInfoResult(ValidationResult, total=False):
     """Result shape for :class:`KeyInfoValidator` (envelope + data)."""
 
     key_type: str
-    key_size: Optional[int]
+    key_size: int | None
     curve: str
 
 
@@ -20,7 +20,7 @@ class KeyInfoResult(ValidationResult, total=False):
 # (rust_certinfo/src/pq_algorithms.rs) via certinfo.pq_algorithms() so
 # Python never carries its own copy of the table — a new algorithm added
 # there is recognized here automatically.
-_PQ_ALGORITHM_NAMES: FrozenSet[str] = frozenset(
+_PQ_ALGORITHM_NAMES: frozenset[str] = frozenset(
     alg["name"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
 )
@@ -53,7 +53,7 @@ class KeyInfoValidator(BaseCertValidator):
 
     name: str = "key_info"
 
-    def validate(self, cert: Dict[str, Any], host: str, port: int) -> KeyInfoResult:
+    def validate(self, cert: dict[str, Any], host: str, port: int) -> KeyInfoResult:
         """
         Validates the key information of the provided SSL certificate.
 
@@ -145,9 +145,9 @@ class KeyInfoValidator(BaseCertValidator):
     @staticmethod
     def _weak_key_reason(
         key_type: str,
-        key_size: Optional[int],
-        curve: Optional[str],
-        strength: Optional[bool],
+        key_size: int | None,
+        curve: str | None,
+        strength: bool | None,
     ) -> str:
         """Explain why a key did not validate as strong.
 
@@ -166,8 +166,8 @@ class KeyInfoValidator(BaseCertValidator):
         return f"Key algorithm {key_type!r} did not meet strength requirements."
 
     def _is_key_strong_enough(
-        self, key_type: str, key_size: Optional[int], curve: Optional[str]
-    ) -> Optional[bool]:
+        self, key_type: str, key_size: int | None, curve: str | None
+    ) -> bool | None:
         """
         Checks if the key is strong enough based on its type, size, and curve.
 

--- a/certmonitor/validators/pq_chain.py
+++ b/certmonitor/validators/pq_chain.py
@@ -1,6 +1,6 @@
 # validators/pq_chain.py
 
-from typing import Any, ClassVar, Dict, FrozenSet, List, Optional
+from typing import Any, ClassVar
 
 from certmonitor import certinfo
 
@@ -11,11 +11,11 @@ from .results import ValidationResult
 # (rust_certinfo/src/pq_algorithms.rs) so Python never carries its own
 # copy of the table. Keys (SPKI) are matched by name; certificate
 # signature algorithms are matched by dotted OID.
-_PQ_KEY_NAMES: FrozenSet[str] = frozenset(
+_PQ_KEY_NAMES: frozenset[str] = frozenset(
     alg["name"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
 )
-_PQ_SIG_OIDS: FrozenSet[str] = frozenset(
+_PQ_SIG_OIDS: frozenset[str] = frozenset(
     alg["dotted"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
 )
@@ -25,8 +25,8 @@ class PqChainResult(ValidationResult, total=False):
     """Result shape for :class:`PqChainValidator` (envelope + data)."""
 
     chain_length: int
-    certs: List[Dict[str, Any]]
-    summary: Dict[str, Optional[bool]]
+    certs: list[dict[str, Any]]
+    summary: dict[str, bool | None]
 
 
 class PqChainValidator(BaseCertValidator):
@@ -67,7 +67,7 @@ class PqChainValidator(BaseCertValidator):
 
     def validate(
         self,
-        cert: Dict[str, Any],
+        cert: dict[str, Any],
         host: str,
         port: int,
         *,
@@ -123,11 +123,11 @@ class PqChainValidator(BaseCertValidator):
         if isinstance(analysis, dict) and "error" in analysis:
             return self._error_result(analysis["error"])
 
-        raw_certs: List[Dict[str, Any]] = list(analysis.get("certs", []))
+        raw_certs: list[dict[str, Any]] = list(analysis.get("certs", []))
         if not raw_certs:
             return self._error_result("Certificate chain is empty.")
 
-        certs: List[Dict[str, Any]] = []
+        certs: list[dict[str, Any]] = []
         for idx, raw in enumerate(raw_certs):
             key_algorithm = raw.get("public_key_info", {}).get("algorithm", "unknown")
             sig_oid = raw.get("signature_algorithm_oid", "")
@@ -180,7 +180,7 @@ class PqChainValidator(BaseCertValidator):
         return result
 
     @staticmethod
-    def _role_all_pq(certs: List[Dict[str, Any]], role: str) -> Optional[bool]:
+    def _role_all_pq(certs: list[dict[str, Any]], role: str) -> bool | None:
         """True/False when every cert of ``role`` is PQ; None when absent."""
         of_role = [entry for entry in certs if entry["role"] == role]
         if not of_role:

--- a/certmonitor/validators/pq_key_exchange.py
+++ b/certmonitor/validators/pq_key_exchange.py
@@ -1,6 +1,6 @@
 # validators/pq_key_exchange.py
 
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar
 
 from .base import BaseCipherValidator
 from .results import ValidationResult
@@ -9,7 +9,7 @@ from .results import ValidationResult
 class PqKeyExchangeResult(ValidationResult, total=False):
     """Result shape for :class:`PqKeyExchangeValidator` (envelope + data)."""
 
-    kem_id: Optional[int]
+    kem_id: int | None
     kem_name: str
     kem_kind: str
     is_pq: bool
@@ -52,12 +52,12 @@ class PqKeyExchangeValidator(BaseCipherValidator):
     """
 
     name: str = "pq_key_exchange"
-    requires: ClassVar[Tuple[str, ...]] = ("cipher_info", "tls_probe")
+    requires: ClassVar[tuple[str, ...]] = ("cipher_info", "tls_probe")
 
     def validate(  # type: ignore[override]  # multi-source: dispatcher injects per `requires`
         self,
-        cipher_info: Dict[str, Any],
-        tls_probe: Dict[str, Any],
+        cipher_info: dict[str, Any],
+        tls_probe: dict[str, Any],
         host: str,
         port: int,
     ) -> PqKeyExchangeResult:

--- a/certmonitor/validators/pq_signature.py
+++ b/certmonitor/validators/pq_signature.py
@@ -1,6 +1,6 @@
 # validators/pq_signature.py
 
-from typing import Any, ClassVar, Dict, FrozenSet, Optional
+from typing import Any, ClassVar
 
 from certmonitor import certinfo
 
@@ -12,20 +12,20 @@ from .results import ValidationResult
 # copy of the table. Keys (SPKI) are matched by name; certificate
 # signature algorithms are matched by dotted OID. Composite entries are
 # tracked separately so the validator can report hybrid composites.
-_PQ_KEY_NAMES: FrozenSet[str] = frozenset(
+_PQ_KEY_NAMES: frozenset[str] = frozenset(
     alg["name"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
 )
-_PQ_SIG_OIDS: FrozenSet[str] = frozenset(
+_PQ_SIG_OIDS: frozenset[str] = frozenset(
     alg["dotted"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
 )
-_COMPOSITE_KEY_NAMES: FrozenSet[str] = frozenset(
+_COMPOSITE_KEY_NAMES: frozenset[str] = frozenset(
     alg["name"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
     if alg["composite"]
 )
-_COMPOSITE_SIG_OIDS: FrozenSet[str] = frozenset(
+_COMPOSITE_SIG_OIDS: frozenset[str] = frozenset(
     alg["dotted"]
     for alg in certinfo.pq_algorithms()  # type: ignore[attr-defined]
     if alg["composite"]
@@ -75,7 +75,7 @@ class PqSignatureValidator(BaseCertValidator):
 
     def validate(
         self,
-        cert: Dict[str, Any],
+        cert: dict[str, Any],
         host: str,
         port: int,
         *,
@@ -172,7 +172,7 @@ class PqSignatureValidator(BaseCertValidator):
         return result
 
     @staticmethod
-    def _leaf(cert: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def _leaf(cert: dict[str, Any]) -> dict[str, Any] | None:
         """The leaf cert dict from chain_analysis, else leaf_analysis."""
         for source in ("chain_analysis", "leaf_analysis"):
             analysis = cert.get(source)

--- a/certmonitor/validators/results.py
+++ b/certmonitor/validators/results.py
@@ -41,12 +41,12 @@ with its data fields (see ``pq_signature.py`` for an example)::
         my_data_field: str
 
 Note:
-    ``typing.NotRequired`` does not exist on Python 3.8 and the project
-    has a zero-dependency rule (no ``typing_extensions``), hence the
-    two-class required/optional split below.
+    ``typing.NotRequired`` is only available on Python 3.11+, and the
+    project has a zero-dependency rule (no ``typing_extensions``), so on the
+    3.10 floor we use the two-class required/optional split below.
 """
 
-from typing import List, TypedDict
+from typing import TypedDict
 
 
 class _ValidationResultBase(TypedDict):
@@ -64,6 +64,6 @@ class ValidationResult(_ValidationResultBase, total=False):
     """
 
     reason: str
-    warnings: List[str]
+    warnings: list[str]
     error: str
     message: str

--- a/certmonitor/validators/root_certificate_validator.py
+++ b/certmonitor/validators/root_certificate_validator.py
@@ -1,6 +1,6 @@
 # validators/root_certificate_validator.py
 
-from typing import Any, Dict, List
+from typing import Any
 
 from .base import BaseCertValidator
 from .results import ValidationResult
@@ -9,7 +9,7 @@ from .results import ValidationResult
 class RootCertificateResult(ValidationResult, total=False):
     """Result shape for :class:`RootCertificateValidator` (envelope + data)."""
 
-    issuer: Dict[str, Any]
+    issuer: dict[str, Any]
 
 
 class RootCertificateValidator(BaseCertValidator):
@@ -23,7 +23,7 @@ class RootCertificateValidator(BaseCertValidator):
     name: str = "root_certificate"
 
     def validate(
-        self, cert: Dict[str, Any], host: str, port: int
+        self, cert: dict[str, Any], host: str, port: int
     ) -> RootCertificateResult:
         """
         Validates if the SSL certificate is issued by a trusted root CA.
@@ -101,7 +101,7 @@ class RootCertificateValidator(BaseCertValidator):
             )
         )
 
-        warnings: List[str] = []
+        warnings: list[str] = []
         if not has_valid_issuer:
             warnings.append("Certificate does not have valid issuer information.")
         if not has_ocsp:

--- a/certmonitor/validators/sensitive_date.py
+++ b/certmonitor/validators/sensitive_date.py
@@ -5,7 +5,7 @@ Module for validating SSL certificates against specified sensitive dates.
 """
 
 from datetime import date, datetime
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, NamedTuple
 
 from ._utils import parse_not_after
 from .base import BaseCertValidator
@@ -17,7 +17,7 @@ class SensitiveDateResult(ValidationResult, total=False):
 
     leapday_expiry: bool
     weekend_expiry: bool
-    sensitive_date_matches: List[Dict[str, str]]
+    sensitive_date_matches: list[dict[str, str]]
 
 
 class SensitiveDate(NamedTuple):
@@ -36,12 +36,7 @@ class SensitiveDate(NamedTuple):
 # Any of these forms may appear in the ``dates`` argument of
 # :meth:`SensitiveDateValidator.validate`. They are all normalized internally
 # to a :class:`SensitiveDate`.
-SensitiveDateInput = Union[
-    SensitiveDate,
-    date,
-    str,
-    Tuple[str, date],
-]
+SensitiveDateInput = SensitiveDate | date | str | tuple[str, date]
 
 
 def _normalize(item: Any) -> SensitiveDate:
@@ -97,11 +92,11 @@ class SensitiveDateValidator(BaseCertValidator):
 
     def validate(
         self,
-        cert: Dict[str, Any],
+        cert: dict[str, Any],
         host: str,
         port: int,
         *,
-        dates: Optional[List[SensitiveDateInput]] = None,
+        dates: list[SensitiveDateInput] | None = None,
     ) -> SensitiveDateResult:
         """
         Validates the sensitivity of the expiry date of the provided SSL certificate.
@@ -160,7 +155,7 @@ class SensitiveDateValidator(BaseCertValidator):
                 }
                 ```
         """
-        normalized: List[SensitiveDate] = []
+        normalized: list[SensitiveDate] = []
         if dates:
             for item in dates:
                 try:
@@ -183,7 +178,7 @@ class SensitiveDateValidator(BaseCertValidator):
         leapday_expiry = expiry_date.month == 2 and expiry_date.day == 29
         weekend_expiry = weekday in (5, 6)
 
-        warnings: List[str] = []
+        warnings: list[str] = []
         if leapday_expiry:
             warnings.append(
                 f"Certificate expires on a leap day ({expiry_date.isoformat()})"
@@ -192,7 +187,7 @@ class SensitiveDateValidator(BaseCertValidator):
             day_name = "Saturday" if weekday == 5 else "Sunday"
             warnings.append(f"Certificate expires on a weekend ({day_name})")
 
-        sensitive_date_matches: List[Dict[str, str]] = []
+        sensitive_date_matches: list[dict[str, str]] = []
         for sd in normalized:
             if expiry_date == sd.date:
                 sensitive_date_matches.append(

--- a/certmonitor/validators/subject_alt_names.py
+++ b/certmonitor/validators/subject_alt_names.py
@@ -1,7 +1,7 @@
 # validators/subject_alt_names.py
 
 import ipaddress
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from .base import BaseCertValidator
 from .results import ValidationResult
@@ -15,10 +15,10 @@ class SubjectAltNamesResult(ValidationResult, total=False):
     ``contains_host`` / ``contains_alternate`` records.
     """
 
-    sans: Optional[Dict[str, List[str]]]
+    sans: dict[str, list[str]] | None
     count: int
-    contains_host: Dict[str, Any]
-    contains_alternate: Dict[str, Any]
+    contains_host: dict[str, Any]
+    contains_alternate: dict[str, Any]
 
 
 class SubjectAltNamesValidator(BaseCertValidator):
@@ -34,11 +34,11 @@ class SubjectAltNamesValidator(BaseCertValidator):
 
     def validate(
         self,
-        cert: Dict[str, Any],
+        cert: dict[str, Any],
         host: str,
         port: int,
         *,
-        alternate_names: Optional[List[str]] = None,
+        alternate_names: list[str] | None = None,
     ) -> SubjectAltNamesResult:
         """
         Validates the SANs in the provided SSL certificate.
@@ -192,8 +192,8 @@ class SubjectAltNamesValidator(BaseCertValidator):
         return result
 
     def _check_name_in_sans_with_reason(
-        self, name: str, dns_sans: List[str], ip_sans: List[str]
-    ) -> Tuple[bool, str]:
+        self, name: str, dns_sans: list[str], ip_sans: list[str]
+    ) -> tuple[bool, str]:
         """Checks if the given name is present in the SANs and provides a reason.
 
         Args:

--- a/certmonitor/validators/tls_version.py
+++ b/certmonitor/validators/tls_version.py
@@ -1,19 +1,19 @@
 # validators/tls_version.py
 
-from typing import Any, Dict, FrozenSet, List, Optional
+from typing import Any
 
 from .base import BaseCipherValidator
 from .results import ValidationResult
 
 # Default acceptable TLS versions. TLS 1.1 and older are deprecated.
 # Override per call with the ``allowed_tls_versions`` user arg.
-_DEFAULT_ALLOWED_TLS_VERSIONS: FrozenSet[str] = frozenset({"TLSv1.2", "TLSv1.3"})
+_DEFAULT_ALLOWED_TLS_VERSIONS: frozenset[str] = frozenset({"TLSv1.2", "TLSv1.3"})
 
 
 class TLSVersionResult(ValidationResult, total=False):
     """Result shape for :class:`TLSVersionValidator` (envelope + data)."""
 
-    protocol_version: Optional[str]
+    protocol_version: str | None
 
 
 class TLSVersionValidator(BaseCipherValidator):
@@ -28,11 +28,11 @@ class TLSVersionValidator(BaseCipherValidator):
 
     def validate(
         self,
-        cipher_info: Dict[str, Any],
+        cipher_info: dict[str, Any],
         host: str,
         port: int,
         *,
-        allowed_tls_versions: Optional[List[str]] = None,
+        allowed_tls_versions: list[str] | None = None,
     ) -> TLSVersionResult:
         """
         Validates the TLS protocol version used by the connection.
@@ -72,7 +72,7 @@ class TLSVersionValidator(BaseCipherValidator):
                 }
                 ```
         """
-        allowed: FrozenSet[str] = (
+        allowed: frozenset[str] = (
             frozenset(allowed_tls_versions)
             if allowed_tls_versions is not None
             else _DEFAULT_ALLOWED_TLS_VERSIONS

--- a/certmonitor/validators/weak_cipher.py
+++ b/certmonitor/validators/weak_cipher.py
@@ -1,6 +1,6 @@
 # validators/weak_cipher.py
 
-from typing import Any, Dict, FrozenSet, List, Optional
+from typing import Any
 
 from .base import BaseCipherValidator
 from .results import ValidationResult
@@ -9,7 +9,7 @@ from .results import ValidationResult
 # configuration. Includes the TLS 1.3 suites (IANA names) and the TLS 1.2
 # ECDHE/DHE AEAD suites (OpenSSL-style names). Override per call with the
 # ``allowed_cipher_suites`` user arg.
-_DEFAULT_ALLOWED_CIPHER_SUITES: FrozenSet[str] = frozenset(
+_DEFAULT_ALLOWED_CIPHER_SUITES: frozenset[str] = frozenset(
     {
         # TLS 1.3 (IANA names, as reported by Python's ssl module).
         "TLS_AES_128_GCM_SHA256",
@@ -33,7 +33,7 @@ _DEFAULT_ALLOWED_CIPHER_SUITES: FrozenSet[str] = frozenset(
 class WeakCipherResult(ValidationResult, total=False):
     """Result shape for :class:`WeakCipherValidator` (envelope + data)."""
 
-    cipher_suite: Optional[str]
+    cipher_suite: str | None
 
 
 class WeakCipherValidator(BaseCipherValidator):
@@ -48,11 +48,11 @@ class WeakCipherValidator(BaseCipherValidator):
 
     def validate(
         self,
-        cipher_info: Dict[str, Any],
+        cipher_info: dict[str, Any],
         host: str,
         port: int,
         *,
-        allowed_cipher_suites: Optional[List[str]] = None,
+        allowed_cipher_suites: list[str] | None = None,
     ) -> WeakCipherResult:
         """
         Validates that the negotiated cipher suite is in the allowed list.
@@ -90,7 +90,7 @@ class WeakCipherValidator(BaseCipherValidator):
                 }
                 ```
         """
-        allowed: FrozenSet[str] = (
+        allowed: frozenset[str] = (
             frozenset(allowed_cipher_suites)
             if allowed_cipher_suites is not None
             else _DEFAULT_ALLOWED_CIPHER_SUITES

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@
 - ⚡ **High Performance:** Async- and batch-friendly. Designed for speed and concurrency.
 - 🧩 **Extensible:** Add your own custom validators for organization-specific checks.
 - 🔮 **Post-Quantum Readiness:** Opt-in validators detect post-quantum (hybrid/pure **ML-KEM**) TLS key exchange and post-quantum certificate keys/signatures (**ML-DSA**, **SLH-DSA**, composite), so you can track quantum-safe migration and *harvest-now-decrypt-later* exposure. See [below](#post-quantum-readiness).
-- 🐍 **Native Python First:** Works out-of-the-box in any Python 3.8+ environment.
+- 🐍 **Native Python First:** Works out-of-the-box in any Python 3.10+ environment.
 - 🦀 **Rust-Powered Parsing:** Certificate parsing and public key extraction are handled by a Rust extension for speed, safety, and correctness. <strong>This is required for advanced public key and elliptic curve features, but all orchestration and logic are pure Python stdlib.</strong>
 - 📦 **Portable:** No system dependencies. Drop it into any project or CI pipeline.
 - 📝 **Comprehensive Docs:** Usage guides, API reference, and advanced guides throughout this site.
@@ -250,7 +250,7 @@ CertMonitor's certificate parser handles untrusted bytes from every TLS handshak
 - **Every parser path returns `Result`.** Malformed input produces a structured error, never a crash. No `.unwrap()` on user-input-derived data.
 - **2.8 billion fuzz iterations, zero crashes.** The parser is continuously fuzz-tested with [cargo-fuzz](https://github.com/rust-lang/cargo-fuzz) (libFuzzer) against adversarial byte sequences. A 1-hour soak run explores 310 code-coverage points and 505 libfuzzer features with zero panics. Run it yourself: `make fuzz`.
 - **130-cert real-world corpus on every CI run.** Every commit is tested against captured certificates from 101 production hosts spanning Google Trust Services, DigiCert, Let's Encrypt, Sectigo, Cloudflare, and more, covering both RSA and ECDSA key types.
-- **540+ Python tests at 99% line coverage, plus 99 Rust unit tests.** The full test suite runs across Python 3.8 to 3.13 and Rust stable on macOS, Ubuntu, and Windows.
+- **540+ Python tests at 99% line coverage, plus 99 Rust unit tests.** The full test suite runs across Python 3.10 to 3.15 and Rust stable on macOS, Ubuntu, and Windows.
 - **`cargo audit` on every PR.** CertMonitor declares a single direct Rust dependency, `pyo3` (the Python bridge). The whole compiled tree is 15 crates, all pyo3 and its helpers, with no third-party parsing crates, scanned for known vulnerabilities on every pull request.
 
 ---

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -56,4 +56,4 @@ Absolutely. CertMonitor is built to be extensible, so you can add your own valid
 
 ## What platforms does CertMonitor support?
 
-CertMonitor runs on any platform with Python 3.8+, with no third-party Python runtime dependencies. Pre-built wheels (which include the Rust components) are provided for major platforms where available. See the installation instructions for details.
+CertMonitor runs on any platform with Python 3.10+, with no third-party Python runtime dependencies. Pre-built wheels (which include the Rust components) are provided for major platforms where available. See the installation instructions for details.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -7,7 +7,7 @@ CertMonitor was born out of real-world frustration. Outages and security inciden
 So I built CertMonitor to take that pain away. The goals were simple:
 
 - **Zero dependencies.** No third-party Python packages, ever. The advanced public key parsing and elliptic curve support are powered by Rust for speed and safety, but you never install a Python dependency to use them.
-- **Portable and secure.** It works out of the box in any Python 3.8+ environment, with a minimal attack surface.
+- **Portable and secure.** It works out of the box in any Python 3.10+ environment, with a minimal attack surface.
 - **Extensible.** Add your own validators for organization-specific checks, compliance rules, or custom certificate logic.
 - **Fast and reliable.** It's designed for high-throughput, concurrent monitoring across many endpoints.
 

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -21,7 +21,7 @@ That's it. There are no third-party Python packages to pull in, so the install i
 
 CertMonitor runs on:
 
-- Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13
+- Python 3.10, 3.11, 3.12, 3.13, 3.14, 3.15
 
 !!! note "Building from source?"
     The note above covers the normal case: installing the published package. A Rust toolchain only comes into play when you're building from source or developing CertMonitor itself (to compile the Rust extension). If that's you, head over to the [Development Guide](../development.md) for the full setup.

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -38,7 +38,6 @@ for name, r in results.items():
 Common surprises:
 
 - **`hostname` fails on an IP address.** Most certs don't list IPs as SANs. See [Using IP Addresses](ip.md).
-- **`chain` / `pq_chain` returns an error on Python 3.8/3.9.** Chain retrieval needs Python 3.10+.
 - **`pq_signature` / `pq_chain` is `false` for a normal site.** This is expected: the cert is classical (EC/RSA), not post-quantum. See [Post-Quantum Cryptography](../concepts/post-quantum.md).
 
 ## Inspecting output

--- a/docs/validators/chain.md
+++ b/docs/validators/chain.md
@@ -84,9 +84,9 @@ flowchart TD
 
 On failure, `is_valid` is `false` and a `reason` field is added.
 
-## Python version requirement
+## How the chain is retrieved
 
-Chain retrieval relies on `SSLSocket.get_verified_chain()` (Python 3.13+) or the stable `_sslobj.get_unverified_chain()` attribute (Python 3.10-3.12). On Python 3.8 or 3.9 the validator returns an informative error dict rather than silently degrading. The rest of CertMonitor continues to work on 3.8+.
+Chain retrieval relies on `SSLSocket.get_verified_chain()` (Python 3.13+) or the stable `_sslobj.get_unverified_chain()` attribute (Python 3.10-3.12). Both are available across every Python version CertMonitor supports (3.10+), so no extra configuration is needed.
 
 ## What is out of scope
 

--- a/docs/validators/index.md
+++ b/docs/validators/index.md
@@ -51,9 +51,9 @@ The default three run out of the box. The opt-in validators are registered and r
 - [TLSVersion](tls_version.md): Validates the negotiated TLS version.
 - [WeakCipher](weak_cipher.md): Validates that the negotiated cipher suite is in the allowed list.
 - [SensitiveDate](sensitive_date.md): Validates that the certificate doesn't expire on built-in or user specified sensitive dates.
-- [Chain](chain.md): Inspects the full TLS certificate chain for structural problems (missing intermediates, out-of-order, expired members). Requires Python 3.10+.
+- [Chain](chain.md): Inspects the full TLS certificate chain for structural problems (missing intermediates, out-of-order, expired members).
 - [PqKeyExchange](pq_key_exchange.md): Judges whether the negotiated TLS key exchange is post-quantum (hybrid or pure ML-KEM).
-- [PqChain](pq_chain.md): Reports the post-quantum posture of every certificate in the presented chain. Requires Python 3.10+.
+- [PqChain](pq_chain.md): Reports the post-quantum posture of every certificate in the presented chain.
 - [PqSignature](pq_signature.md): Judges the leaf certificate's post-quantum posture (key and signature algorithm).
 
 ## What the output looks like

--- a/docs/validators/pq_chain.md
+++ b/docs/validators/pq_chain.md
@@ -34,8 +34,9 @@ with CertMonitor("example.com", enabled_validators=["pq_chain"]) as m:
 #   m.validate(validator_args={"pq_chain": {"require_full_chain": True}})
 ```
 
-Chain retrieval requires Python 3.10+ (same constraint as the `chain`
-validator); older interpreters get a structured error.
+Chain retrieval uses the same stdlib APIs as the `chain` validator, available
+on every supported Python version. If the chain cannot be fetched (for example
+an unreachable issuer), you get a structured error instead of the report below.
 
 ## How it decides
 
@@ -44,7 +45,7 @@ key by default (or the whole chain with `require_full_chain`).
 
 ```mermaid
 flowchart TD
-    A[validate called] --> B{Chain available?<br/>Python 3.10+}
+    A[validate called] --> B{Chain available?}
     B -- No --> Z["structured error"]
     B -- Yes --> C[For each certificate:<br/>is_pq = key_is_pq OR signature_is_pq]
     C --> D[Summarize by role:<br/>leaf_pq / intermediate_pq / root_pq]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.8,<3.14"
+requires-python = ">=3.10,<3.16"
 keywords = [
     "tls",
     "ssl",
@@ -36,12 +36,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Security",
     "Topic :: Security :: Cryptography",
@@ -78,9 +77,21 @@ module-name = "certmonitor.certinfo"
 # python-source = "certmonitor"
 features = ["pyo3/extension-module"]
 
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+# Keep ruff's default rules (E4/E7/E9, F) and add pyupgrade (UP) so the
+# codebase stays modern for the Python 3.10+ floor (builtin generics,
+# `X | None` unions). extend-select avoids enabling E501 and friends.
+extend-select = ["UP"]
+# UP038 rewrites isinstance(x, (A, B)) to isinstance(x, A | B), which is
+# measurably slower at runtime; keep the tuple form.
+ignore = ["UP038"]
+
 [tool.mypy]
 # MyPy configuration for CertMonitor
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/scripts/bench_chain.py
+++ b/scripts/bench_chain.py
@@ -28,7 +28,6 @@ import statistics
 import sys
 import time
 from pathlib import Path
-from typing import List, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -39,7 +38,7 @@ from certmonitor import CertMonitor, certinfo  # noqa: E402
 # (Google Trust Services, DigiCert, Let's Encrypt, Sectigo, Amazon, etc.),
 # chain depths, key types (RSA + ECDSA), and to avoid hosts that are known
 # to require unusual user agents or aggressive rate limiting.
-HOSTS: List[str] = [
+HOSTS: list[str] = [
     # Google
     "google.com",
     "www.google.com",
@@ -159,7 +158,7 @@ HOSTS: List[str] = [
 ]
 
 
-def _percentile(sorted_samples: List[float], p: float) -> float:
+def _percentile(sorted_samples: list[float], p: float) -> float:
     if not sorted_samples:
         return 0.0
     k = min(int(len(sorted_samples) * p), len(sorted_samples) - 1)
@@ -174,7 +173,7 @@ def microbench(iterations: int) -> None:
     for _ in range(200):
         certinfo.analyze_chain(chain)
 
-    samples: List[float] = []
+    samples: list[float] = []
     for _ in range(iterations):
         t = time.perf_counter()
         certinfo.analyze_chain(chain)
@@ -199,7 +198,7 @@ def microbench(iterations: int) -> None:
 
 def _run_one(
     host: str, port: int, timeout: float
-) -> Tuple[str, bool, float, int, bool, str]:
+) -> tuple[str, bool, float, int, bool, str]:
     """Run CertMonitor synchronously. Returns (host, ok, elapsed_s, chain_len, chain_valid, error)."""
     start = time.perf_counter()
     try:
@@ -233,7 +232,7 @@ def _run_one(
 
 async def _bounded(
     sem: asyncio.Semaphore, host: str, port: int, timeout: float
-) -> Tuple[str, bool, float, int, bool, str]:
+) -> tuple[str, bool, float, int, bool, str]:
     async with sem:
         try:
             return await asyncio.wait_for(
@@ -245,7 +244,7 @@ async def _bounded(
 
 
 async def pipeline_bench(
-    hosts: List[str], concurrency: int, port: int, timeout: float, verbose: bool
+    hosts: list[str], concurrency: int, port: int, timeout: float, verbose: bool
 ) -> None:
     print("=" * 64)
     print(

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -10,11 +10,11 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Tuple, Any
+from typing import Any
 import ast
 
 
-def run_command(cmd: str) -> Tuple[str, int]:
+def run_command(cmd: str) -> tuple[str, int]:
     """Run a shell command and return output and exit code.
 
     Note: This is an internal development script with controlled commands.
@@ -30,10 +30,10 @@ def run_command(cmd: str) -> Tuple[str, int]:
         return f"Error running command: {e}", 1
 
 
-def get_file_stats(file_path: Path) -> Dict[str, Any]:
+def get_file_stats(file_path: Path) -> dict[str, Any]:
     """Get statistics for a Python file."""
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         lines = content.split("\n")
@@ -73,7 +73,7 @@ def get_file_stats(file_path: Path) -> Dict[str, Any]:
         }
 
 
-def analyze_test_modularization() -> Dict[str, Any]:
+def analyze_test_modularization() -> dict[str, Any]:
     """Analyze the test file organization and modularization."""
     test_core_dir = Path("tests/test_core")
     main_test_file = Path("tests/test_core.py")
@@ -107,7 +107,7 @@ def analyze_test_modularization() -> Dict[str, Any]:
     return results
 
 
-def get_test_coverage() -> Dict[str, Any]:
+def get_test_coverage() -> dict[str, Any]:
     """Get test coverage information."""
     # Run pytest with coverage
     coverage_cmd = (
@@ -121,7 +121,7 @@ def get_test_coverage() -> Dict[str, Any]:
     coverage_file = Path("coverage.json")
     if coverage_file.exists():
         try:
-            with open(coverage_file, "r") as f:
+            with open(coverage_file) as f:
                 coverage_json = json.load(f)
 
             coverage_data = {
@@ -154,7 +154,7 @@ def get_test_coverage() -> Dict[str, Any]:
     return coverage_data
 
 
-def analyze_type_hints() -> Dict[str, Any]:
+def analyze_type_hints() -> dict[str, Any]:
     """Analyze type hint coverage across the codebase."""
     certmonitor_dir = Path("certmonitor")
     results = {
@@ -172,7 +172,7 @@ def analyze_type_hints() -> Dict[str, Any]:
             continue
 
         try:
-            with open(py_file, "r", encoding="utf-8") as f:
+            with open(py_file, encoding="utf-8") as f:
                 content = f.read()
 
             # Check for type hints
@@ -206,7 +206,7 @@ def analyze_type_hints() -> Dict[str, Any]:
     return results
 
 
-def get_code_quality_metrics() -> Dict[str, Any]:
+def get_code_quality_metrics() -> dict[str, Any]:
     """Get code quality metrics from ruff and other tools."""
     results = {}
 
@@ -236,7 +236,7 @@ def get_code_quality_metrics() -> Dict[str, Any]:
     return results
 
 
-def get_security_metrics() -> Dict[str, Any]:
+def get_security_metrics() -> dict[str, Any]:
     """Get security-related metrics and scan results."""
     results = {
         "cargo_audit_available": False,
@@ -266,7 +266,7 @@ def get_security_metrics() -> Dict[str, Any]:
         bandit_report_path = Path("bandit-report.json")
         if bandit_report_path.exists():
             try:
-                with open(bandit_report_path, "r", encoding="utf-8") as f:
+                with open(bandit_report_path, encoding="utf-8") as f:
                     bandit_data = json.load(f)
 
                 results["bandit_issues_found"] = len(bandit_data.get("results", []))
@@ -316,7 +316,7 @@ def get_security_metrics() -> Dict[str, Any]:
     try:
         cargo_toml = Path("Cargo.toml")
         if cargo_toml.exists():
-            with open(cargo_toml, "r") as f:
+            with open(cargo_toml) as f:
                 content = f.read()
                 for line in content.split("\n"):
                     if "pyo3" in line and "version" in line:
@@ -331,7 +331,7 @@ def get_security_metrics() -> Dict[str, Any]:
     return results
 
 
-def get_makefile_metrics() -> Dict[str, Any]:
+def get_makefile_metrics() -> dict[str, Any]:
     """Analyze Makefile commands and development workflow capabilities."""
     results = {
         "makefile_exists": False,
@@ -350,7 +350,7 @@ def get_makefile_metrics() -> Dict[str, Any]:
     results["makefile_exists"] = True
 
     try:
-        with open(makefile_path, "r") as f:
+        with open(makefile_path) as f:
             content = f.read()
 
         # Count command targets (lines that start with word and colon, not indented)

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -7,6 +7,7 @@ and code quality metrics to ensure the codebase remains modular and maintainable
 """
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -387,20 +388,18 @@ def get_makefile_metrics() -> dict[str, Any]:
             elif any(pattern in cmd for pattern in security_patterns):
                 results["security_commands"].append(cmd)
 
-        # Count test steps by looking for numbered steps in test target
+        # Count test steps by looking for numbered "N/M" step markers in the
+        # test target. The denominator is the advertised step count, so this
+        # stays correct no matter how many steps the target grows to.
         if "test:" in content:
-            test_section = (
-                content.split("test:")[1].split("\n\n")[0] if "test:" in content else ""
-            )
-            step_count = (
-                test_section.count("/9")
-                + test_section.count("/8")
-                + test_section.count("/7")
-            )
-            if step_count > 0:
-                results["test_steps"] = (
-                    9 if "/9" in test_section else (8 if "/8" in test_section else 7)
-                )
+            test_section = content.split("test:")[1].split("\n\n")[0]
+            denominators = [int(d) for d in re.findall(r"\b\d+/(\d+)\b", test_section)]
+            if denominators:
+                results["test_steps"] = max(denominators)
+                results["ci_equivalent"] = True
+            elif "CI equivalent" in test_section:
+                # Fallback: the target advertises itself as CI-equivalent even
+                # if the step markers ever change format.
                 results["ci_equivalent"] = True
 
     except Exception:
@@ -579,11 +578,11 @@ def generate_report() -> str:
 ### CI-Equivalent Testing
 """
 
-    report += f"- **Test workflow steps:** {makefile_metrics['test_steps']}/9\n"
+    report += f"- **Test workflow steps:** {makefile_metrics['test_steps']}\n"
     report += f"- **CI-equivalent testing:** {'✅ Yes' if makefile_metrics['ci_equivalent'] else '❌ No'}\n"
 
     if makefile_metrics["ci_equivalent"]:
-        report += "- **Workflow status:** 🚀 Full 9-step testing process available\n"
+        report += f"- **Workflow status:** 🚀 Full {makefile_metrics['test_steps']}-step testing process available\n"
     else:
         report += "- **Workflow status:** ⚠️ Basic testing only\n"
 
@@ -673,7 +672,7 @@ make report
     if makefile_metrics["makefile_exists"] and makefile_metrics["ci_equivalent"]:
         report += """```bash
 # 🚀 Recommended CI-equivalent workflow
-make test          # Full 9-step test suite (format, lint, typecheck, test, build)
+make test          # Full CI-equivalent test suite (format, lint, typecheck, test, build)
 make check         # Quick quality checks (format + lint)
 make develop       # Install for development
 

--- a/tests/test_core/test_certificate_operations.py
+++ b/tests/test_core/test_certificate_operations.py
@@ -291,8 +291,9 @@ class TestCertificateFetching:
             "ordered": True,
             "terminates_in_self_signed": False,
         }
-        with patch("certmonitor.core.certinfo") as mock_certinfo, patch.object(
-            monitor, "_ensure_connection", return_value=None
+        with (
+            patch("certmonitor.core.certinfo") as mock_certinfo,
+            patch.object(monitor, "_ensure_connection", return_value=None),
         ):
             mock_certinfo.parse_public_key_info.return_value = {
                 "algorithm": "rsaEncryption",
@@ -323,8 +324,9 @@ class TestCertificateFetching:
         monitor.handler = mock_handler
         monitor.connected = True
 
-        with patch("certmonitor.core.certinfo") as mock_certinfo, patch.object(
-            monitor, "_ensure_connection", return_value=None
+        with (
+            patch("certmonitor.core.certinfo") as mock_certinfo,
+            patch.object(monitor, "_ensure_connection", return_value=None),
         ):
             mock_certinfo.parse_public_key_info.return_value = {
                 "algorithm": "rsaEncryption",
@@ -355,8 +357,9 @@ class TestCertificateFetching:
         monitor.handler = mock_handler
         monitor.connected = True
 
-        with patch("certmonitor.core.certinfo") as mock_certinfo, patch.object(
-            monitor, "_ensure_connection", return_value=None
+        with (
+            patch("certmonitor.core.certinfo") as mock_certinfo,
+            patch.object(monitor, "_ensure_connection", return_value=None),
         ):
             mock_certinfo.parse_public_key_info.return_value = {
                 "algorithm": "rsaEncryption",

--- a/tests/test_core/test_connection_management.py
+++ b/tests/test_core/test_connection_management.py
@@ -1,6 +1,5 @@
 """Tests for CertMonitor connection management functionality."""
 
-import socket
 from unittest.mock import MagicMock, patch
 
 from certmonitor import CertMonitor
@@ -191,7 +190,7 @@ class TestProtocolDetection:
         monitor = CertMonitor("www.example.com")
 
         mock_socket = MagicMock()
-        mock_socket.recv.side_effect = socket.error("No data")
+        mock_socket.recv.side_effect = OSError("No data")
 
         with patch("certmonitor.core.socket.create_connection") as mock_create:
             mock_create.return_value.__enter__.return_value = mock_socket

--- a/tests/test_core/test_utility_methods.py
+++ b/tests/test_core/test_utility_methods.py
@@ -102,7 +102,7 @@ class TestDescribeValidators:
         arg = san["args"]["alternate_names"]
         assert arg["default"] is None
         assert arg["required"] is False
-        assert "List" in arg["annotation"] and "str" in arg["annotation"]
+        assert "list[str]" in arg["annotation"] and "None" in arg["annotation"]
 
     def test_describe_validators_validator_with_no_args(self):
         """Validators without user args report an empty args dict."""

--- a/tests/test_protocol_handlers/test_ssh_handler.py
+++ b/tests/test_protocol_handlers/test_ssh_handler.py
@@ -1,4 +1,3 @@
-import socket
 from unittest.mock import MagicMock, patch
 
 from certmonitor.error_handlers import ErrorHandler
@@ -42,7 +41,7 @@ class TestSSHHandler:
         error_handler = ErrorHandler()
         ssh_handler = SSHHandler("test.example.com", 22, error_handler)
 
-        mock_create_connection.side_effect = socket.error("Connection refused")
+        mock_create_connection.side_effect = OSError("Connection refused")
 
         result = ssh_handler.connect()
 
@@ -134,7 +133,7 @@ class TestSSHHandler:
         ssh_handler.socket = mock_socket
 
         # Mock socket exception
-        mock_socket.recv.side_effect = socket.error("Connection reset")
+        mock_socket.recv.side_effect = OSError("Connection reset")
 
         result = ssh_handler.fetch_raw_cert()
 
@@ -210,7 +209,7 @@ class TestSSHHandler:
         ssh_handler.socket = mock_socket
 
         # Mock socket error on getpeername call
-        mock_socket.getpeername.side_effect = socket.error("Connection lost")
+        mock_socket.getpeername.side_effect = OSError("Connection lost")
 
         result = ssh_handler.check_connection()
 

--- a/tests/test_protocol_handlers/test_ssl_handler.py
+++ b/tests/test_protocol_handlers/test_ssl_handler.py
@@ -229,8 +229,13 @@ class TestSSLHandler:
         assert result["chain_der"] == [b"DER_A", b"DER_B"]
         assert result["chain_error"] is None
 
-    def test_fetch_raw_cert_chain_unavailable_on_old_python(self, ssl_handler):
-        """3.8/3.9 path: neither public API nor _sslobj.get_unverified_chain."""
+    def test_fetch_raw_cert_chain_unavailable(self, ssl_handler):
+        """Defensive path: neither public API nor _sslobj.get_unverified_chain.
+
+        Every supported interpreter (3.10+) exposes at least one of these, so
+        this branch is not reachable in practice, but the handler degrades
+        gracefully to the leaf cert with an informative error if it ever is.
+        """
         mock_secure_socket = MagicMock(spec=["getpeercert"])
         ssl_handler.secure_socket = mock_secure_socket
 
@@ -244,7 +249,7 @@ class TestSSLHandler:
             result = ssl_handler.fetch_raw_cert()
 
         assert result["chain_der"] is None
-        assert "Python 3.10" in result["chain_error"]
+        assert "not available on this interpreter" in result["chain_error"]
 
     def test_fetch_raw_cert_chain_public_api_exception(self, ssl_handler):
         mock_secure_socket = MagicMock(spec=["getpeercert", "get_verified_chain"])

--- a/tests/test_protocol_handlers/test_ssl_handler.py
+++ b/tests/test_protocol_handlers/test_ssl_handler.py
@@ -1,6 +1,5 @@
 # tests/test_protocol_handlers/test_ssl_handler.py
 
-import socket
 import ssl
 from unittest.mock import MagicMock, patch
 
@@ -75,7 +74,7 @@ class TestSSLHandler:
     @patch("socket.create_connection")
     def test_connect_socket_error(self, mock_create_connection, ssl_handler):
         """Test connection failure due to socket error."""
-        mock_create_connection.side_effect = socket.error("Connection refused")
+        mock_create_connection.side_effect = OSError("Connection refused")
 
         with patch.object(
             ssl_handler,
@@ -221,8 +220,9 @@ class TestSSLHandler:
             fake_cert_b,
         ]
 
-        with patch("ssl.DER_cert_to_PEM_cert", return_value="pem"), patch(
-            "ssl.PEM_cert_to_DER_cert", side_effect=[b"DER_A", b"DER_B"]
+        with (
+            patch("ssl.DER_cert_to_PEM_cert", return_value="pem"),
+            patch("ssl.PEM_cert_to_DER_cert", side_effect=[b"DER_A", b"DER_B"]),
         ):
             result = ssl_handler.fetch_raw_cert()
 
@@ -623,10 +623,10 @@ class TestSSLHandler:
                 # Second call (retry) raises a different exception
                 raise ssl.SSLError("Some other SSL error during retry")
 
-        with patch("socket.socket", return_value=mock_socket), patch(
-            "ssl.SSLContext"
-        ) as mock_context_class, patch.object(
-            handler, "get_supported_protocols", return_value=["TLSv1_2"]
+        with (
+            patch("socket.socket", return_value=mock_socket),
+            patch("ssl.SSLContext") as mock_context_class,
+            patch.object(handler, "get_supported_protocols", return_value=["TLSv1_2"]),
         ):
             mock_context = MagicMock()
             mock_context_class.return_value = mock_context

--- a/tests/test_validators/test_base.py
+++ b/tests/test_validators/test_base.py
@@ -208,7 +208,6 @@ class TestUserArgEnforcement:
 
     def test_validator_with_well_formed_user_arg_is_allowed(self):
         """A keyword-only, annotated, defaulted user arg is accepted."""
-        from typing import Optional, List
 
         class WellFormedValidator(BaseCertValidator):
             @property
@@ -221,7 +220,7 @@ class TestUserArgEnforcement:
                 host,
                 port,
                 *,
-                names: Optional[List[str]] = None,
+                names: list[str] | None = None,
             ):
                 return {"is_valid": True, "names": names}
 
@@ -255,7 +254,6 @@ class TestUserArgEnforcement:
 
     def test_validator_with_no_default_user_arg_is_rejected(self):
         """A keyword-only annotated user arg without a default fails."""
-        from typing import List
 
         with pytest.raises(TypeError, match="missing default value"):
 
@@ -264,7 +262,7 @@ class TestUserArgEnforcement:
                 def name(self):
                     return "bad_no_default"
 
-                def validate(self, cert_info, host, port, *, names: List[str]):
+                def validate(self, cert_info, host, port, *, names: list[str]):
                     return {"is_valid": True}
 
     def test_validator_with_var_positional_is_rejected(self):

--- a/tests/test_validators/test_chain.py
+++ b/tests/test_validators/test_chain.py
@@ -1,7 +1,7 @@
 # tests/test_validators/test_chain.py
 
 import datetime
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -14,7 +14,7 @@ def validator():
     return ChainValidator()
 
 
-def _wrap(analysis: Dict[str, Any], chain_error=None) -> Dict[str, Any]:
+def _wrap(analysis: dict[str, Any], chain_error=None) -> dict[str, Any]:
     return {
         "cert_info": {},
         "chain_analysis": analysis,

--- a/uv.lock
+++ b/uv.lock
@@ -1,32 +1,11 @@
 version = 1
 revision = 3
-requires-python = ">=3.8, <3.14"
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
-]
-
-[[package]]
-name = "astunparse"
-version = "1.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six", marker = "python_full_version < '3.9'" },
-    { name = "wheel", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290, upload-time = "2019-12-22T18:12:13.129Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8", size = 12732, upload-time = "2019-12-22T18:12:11.297Z" },
-]
+requires-python = ">=3.10, <3.16"
 
 [[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytz", marker = "python_full_version < '3.9'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
@@ -34,28 +13,8 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "5.7.post1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/30/903f35159c87ff1d92aa3fcf8cb52de97632a21e0ae43ed940f5d033e01a/backrefs-5.7.post1.tar.gz", hash = "sha256:8b0f83b770332ee2f1c8244f4e03c77d127a0fa529328e6a0e77fa25bee99678", size = 6582270, upload-time = "2024-06-16T18:38:20.166Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/bb/47fc255d1060dcfd55b460236380edd8ebfc5b2a42a0799ca90c9fc983e3/backrefs-5.7.post1-py310-none-any.whl", hash = "sha256:c5e3fd8fd185607a7cb1fefe878cfb09c34c0be3c18328f12c574245f1c0287e", size = 380429, upload-time = "2024-06-16T18:38:10.131Z" },
-    { url = "https://files.pythonhosted.org/packages/89/72/39ef491caef3abae945f5a5fd72830d3b596bfac0630508629283585e213/backrefs-5.7.post1-py311-none-any.whl", hash = "sha256:712ea7e494c5bf3291156e28954dd96d04dc44681d0e5c030adf2623d5606d51", size = 392234, upload-time = "2024-06-16T18:38:12.283Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/00/33403f581b732ca70fdebab558e8bbb426a29c34e0c3ed674a479b74beea/backrefs-5.7.post1-py312-none-any.whl", hash = "sha256:a6142201c8293e75bce7577ac29e1a9438c12e730d73a59efdd1b75528d1a6c5", size = 398110, upload-time = "2024-06-16T18:38:14.257Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ea/df0ac74a26838f6588aa012d5d801831448b87d0a7d0aefbbfabbe894870/backrefs-5.7.post1-py38-none-any.whl", hash = "sha256:ec61b1ee0a4bfa24267f6b67d0f8c5ffdc8e0d7dc2f18a2685fd1d8d9187054a", size = 369477, upload-time = "2024-06-16T18:38:16.196Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/e8/e43f535c0a17a695e5768670fc855a0e5d52dc0d4135b3915bfa355f65ac/backrefs-5.7.post1-py39-none-any.whl", hash = "sha256:05c04af2bf752bb9a6c9dcebb2aff2fab372d3d9d311f2a138540e307756bd3a", size = 380429, upload-time = "2024-06-16T18:38:18.079Z" },
-]
-
-[[package]]
-name = "backrefs"
 version = "5.8"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/46/caba1eb32fa5784428ab401a5487f73db4104590ecd939ed9daaf18b47e0/backrefs-5.8.tar.gz", hash = "sha256:2cab642a205ce966af3dd4b38ee36009b31fa9502a35fd61d59ccc116e40a6bd", size = 6773994, upload-time = "2025-02-25T18:15:32.003Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/cb/d019ab87fe70e0fe3946196d50d6a4428623dc0c38a6669c8cae0320fbf3/backrefs-5.8-py310-none-any.whl", hash = "sha256:c67f6638a34a5b8730812f5101376f9d41dc38c43f1fdc35cb54700f6ed4465d", size = 380337, upload-time = "2025-02-25T16:53:14.607Z" },
@@ -67,35 +26,13 @@ wheels = [
 
 [[package]]
 name = "bandit"
-version = "1.7.10"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
-    { name = "pyyaml", marker = "python_full_version < '3.9'" },
-    { name = "rich", marker = "python_full_version < '3.9'" },
-    { name = "stevedore", version = "5.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/26/bdd962d6ee781f6229c3fb83483cf9e09d87959150a9000789806d750f3c/bandit-1.7.10.tar.gz", hash = "sha256:59ed5caf5d92b6ada4bf65bc6437feea4a9da1093384445fed4d472acc6cff7b", size = 4228540, upload-time = "2024-09-23T17:33:34.099Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/9c/491231d973d54f6465002812b4cadc663f208436407745be473254725f55/bandit-1.7.10-py3-none-any.whl", hash = "sha256:665721d7bebbb4485a339c55161ac0eedde27d51e638000d91c8c2d68343ad02", size = 130756, upload-time = "2024-09-23T17:33:32.428Z" },
-]
-
-[[package]]
-name = "bandit"
 version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.9' and sys_platform == 'win32'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.9'" },
-    { name = "rich", marker = "python_full_version >= '3.9'" },
-    { name = "stevedore", version = "5.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/a5/144a45f8e67df9d66c3bc3f7e69a39537db8bff1189ab7cff4e9459215da/bandit-1.8.3.tar.gz", hash = "sha256:f5847beb654d309422985c36644649924e0ea4425c76dec2e89110b87506193a", size = 4232005, upload-time = "2025-02-17T05:24:57.031Z" }
 wheels = [
@@ -131,14 +68,11 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "bandit", version = "1.7.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "bandit", version = "1.8.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "bandit" },
     { name = "maturin" },
-    { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mypy", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "mypy" },
     { name = "pytest" },
-    { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest-cov", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
@@ -146,10 +80,8 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
-    { name = "mkdocstrings", version = "0.26.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mkdocstrings", version = "0.29.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "mkdocstrings-python", version = "1.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mkdocstrings-python", version = "1.16.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "mkdocstrings" },
+    { name = "mkdocstrings-python" },
 ]
 
 [package.metadata]
@@ -230,60 +162,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload-time = "2025-05-02T08:33:15.458Z" },
     { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload-time = "2025-05-02T08:33:17.06Z" },
     { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload-time = "2025-05-02T08:33:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fd/f700cfd4ad876def96d2c769d8a32d808b12d1010b6003dc6639157f99ee/charset_normalizer-3.4.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:76af085e67e56c8816c3ccf256ebd136def2ed9654525348cfa744b6802b69eb", size = 198257, upload-time = "2025-05-02T08:33:45.511Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/95/6eec4cbbbd119e6a402e3bfd16246785cc52ce64cf21af2ecdf7b3a08e91/charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e45ba65510e2647721e35323d6ef54c7974959f6081b58d4ef5d87c60c84919a", size = 143453, upload-time = "2025-05-02T08:33:47.463Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/b3/d4f913660383b3d93dbe6f687a312ea9f7e89879ae883c4e8942048174d4/charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45", size = 153130, upload-time = "2025-05-02T08:33:50.568Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/69/7540141529eabc55bf19cc05cd9b61c2078bebfcdbd3e799af99b777fc28/charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75d10d37a47afee94919c4fab4c22b9bc2a8bf7d4f46f87363bcf0573f3ff4f5", size = 145688, upload-time = "2025-05-02T08:33:52.828Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/bb/d76d3d6e340fb0967c43c564101e28a78c9a363ea62f736a68af59ee3683/charset_normalizer-3.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6333b3aa5a12c26b2a4d4e7335a28f1475e0e5e17d69d55141ee3cab736f66d1", size = 147418, upload-time = "2025-05-02T08:33:54.718Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/ef/b7c1f39c0dc3808160c8b72e0209c2479393966313bfebc833533cfff9cc/charset_normalizer-3.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8323a9b031aa0393768b87f04b4164a40037fb2a3c11ac06a03ffecd3618027", size = 150066, upload-time = "2025-05-02T08:33:56.597Z" },
-    { url = "https://files.pythonhosted.org/packages/20/26/4e47cc23d2a4a5eb6ed7d6f0f8cda87d753e2f8abc936d5cf5ad2aae8518/charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:24498ba8ed6c2e0b56d4acbf83f2d989720a93b41d712ebd4f4979660db4417b", size = 144499, upload-time = "2025-05-02T08:33:58.637Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/9c/efdf59dd46593cecad0548d36a702683a0bdc056793398a9cd1e1546ad21/charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:844da2b5728b5ce0e32d863af26f32b5ce61bc4273a9c720a9f3aa9df73b1455", size = 152954, upload-time = "2025-05-02T08:34:00.552Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b3/4e8b73f7299d9aaabd7cd26db4a765f741b8e57df97b034bb8de15609002/charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:65c981bdbd3f57670af8b59777cbfae75364b483fa8a9f420f08094531d54a01", size = 155876, upload-time = "2025-05-02T08:34:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/53/cb/6fa0ccf941a069adce3edb8a1e430bc80e4929f4d43b5140fdf8628bdf7d/charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:3c21d4fca343c805a52c0c78edc01e3477f6dd1ad7c47653241cf2a206d4fc58", size = 153186, upload-time = "2025-05-02T08:34:04.481Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/c6/80b93fabc626b75b1665ffe405e28c3cef0aae9237c5c05f15955af4edd8/charset_normalizer-3.4.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dc7039885fa1baf9be153a0626e337aa7ec8bf96b0128605fb0d77788ddc1681", size = 148007, upload-time = "2025-05-02T08:34:06.888Z" },
-    { url = "https://files.pythonhosted.org/packages/41/eb/c7367ac326a2628e4f05b5c737c86fe4a8eb3ecc597a4243fc65720b3eeb/charset_normalizer-3.4.2-cp38-cp38-win32.whl", hash = "sha256:8272b73e1c5603666618805fe821edba66892e2870058c94c53147602eab29c7", size = 97923, upload-time = "2025-05-02T08:34:08.792Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/02/1c82646582ccf2c757fa6af69b1a3ea88744b8d2b4ab93b7686b2533e023/charset_normalizer-3.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:70f7172939fdf8790425ba31915bfbe8335030f05b9913d7ae00a87d4395620a", size = 105020, upload-time = "2025-05-02T08:34:10.6Z" },
-    { url = "https://files.pythonhosted.org/packages/28/f8/dfb01ff6cc9af38552c69c9027501ff5a5117c4cc18dcd27cb5259fa1888/charset_normalizer-3.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4", size = 201671, upload-time = "2025-05-02T08:34:12.696Z" },
-    { url = "https://files.pythonhosted.org/packages/32/fb/74e26ee556a9dbfe3bd264289b67be1e6d616329403036f6507bb9f3f29c/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7", size = 144744, upload-time = "2025-05-02T08:34:14.665Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/06/8499ee5aa7addc6f6d72e068691826ff093329fe59891e83b092ae4c851c/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836", size = 154993, upload-time = "2025-05-02T08:34:17.134Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/a2/5e4c187680728219254ef107a6949c60ee0e9a916a5dadb148c7ae82459c/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597", size = 147382, upload-time = "2025-05-02T08:34:19.081Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/56aca740dda674f0cc1ba1418c4d84534be51f639b5f98f538b332dc9a95/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7", size = 149536, upload-time = "2025-05-02T08:34:21.073Z" },
-    { url = "https://files.pythonhosted.org/packages/53/13/db2e7779f892386b589173dd689c1b1e304621c5792046edd8a978cbf9e0/charset_normalizer-3.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f", size = 151349, upload-time = "2025-05-02T08:34:23.193Z" },
-    { url = "https://files.pythonhosted.org/packages/69/35/e52ab9a276186f729bce7a0638585d2982f50402046e4b0faa5d2c3ef2da/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba", size = 146365, upload-time = "2025-05-02T08:34:25.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/d8/af7333f732fc2e7635867d56cb7c349c28c7094910c72267586947561b4b/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12", size = 154499, upload-time = "2025-05-02T08:34:27.359Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/3d/a5b2e48acef264d71e036ff30bcc49e51bde80219bb628ba3e00cf59baac/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518", size = 157735, upload-time = "2025-05-02T08:34:29.798Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d8/23e2c112532a29f3eef374375a8684a4f3b8e784f62b01da931186f43494/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5", size = 154786, upload-time = "2025-05-02T08:34:31.858Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/57/93e0169f08ecc20fe82d12254a200dfaceddc1c12a4077bf454ecc597e33/charset_normalizer-3.4.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3", size = 150203, upload-time = "2025-05-02T08:34:33.88Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9d/9bf2b005138e7e060d7ebdec7503d0ef3240141587651f4b445bdf7286c2/charset_normalizer-3.4.2-cp39-cp39-win32.whl", hash = "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471", size = 98436, upload-time = "2025-05-02T08:34:35.907Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/24/5849d46cf4311bbf21b424c443b09b459f5b436b1558c04e45dbb7cc478b/charset_normalizer-3.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e", size = 105772, upload-time = "2025-05-02T08:34:37.935Z" },
     { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -301,99 +188,8 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/08/7e37f82e4d1aead42a7443ff06a1e406aabf7302c4f00a546e4b320b994c/coverage-7.6.1.tar.gz", hash = "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d", size = 798791, upload-time = "2024-08-04T19:45:30.9Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/61/eb7ce5ed62bacf21beca4937a90fe32545c91a3c8a42a30c6616d48fc70d/coverage-7.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16", size = 206690, upload-time = "2024-08-04T19:43:07.695Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/73/041928e434442bd3afde5584bdc3f932fb4562b1597629f537387cec6f3d/coverage-7.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36", size = 207127, upload-time = "2024-08-04T19:43:10.15Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/c8/6ca52b5147828e45ad0242388477fdb90df2c6cbb9a441701a12b3c71bc8/coverage-7.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02", size = 235654, upload-time = "2024-08-04T19:43:12.405Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/da/9ac2b62557f4340270942011d6efeab9833648380109e897d48ab7c1035d/coverage-7.6.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc", size = 233598, upload-time = "2024-08-04T19:43:14.078Z" },
-    { url = "https://files.pythonhosted.org/packages/53/23/9e2c114d0178abc42b6d8d5281f651a8e6519abfa0ef460a00a91f80879d/coverage-7.6.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23", size = 234732, upload-time = "2024-08-04T19:43:16.632Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/7e/a0230756fb133343a52716e8b855045f13342b70e48e8ad41d8a0d60ab98/coverage-7.6.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34", size = 233816, upload-time = "2024-08-04T19:43:19.049Z" },
-    { url = "https://files.pythonhosted.org/packages/28/7c/3753c8b40d232b1e5eeaed798c875537cf3cb183fb5041017c1fdb7ec14e/coverage-7.6.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c", size = 232325, upload-time = "2024-08-04T19:43:21.246Z" },
-    { url = "https://files.pythonhosted.org/packages/57/e3/818a2b2af5b7573b4b82cf3e9f137ab158c90ea750a8f053716a32f20f06/coverage-7.6.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959", size = 233418, upload-time = "2024-08-04T19:43:22.945Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/fb/4532b0b0cefb3f06d201648715e03b0feb822907edab3935112b61b885e2/coverage-7.6.1-cp310-cp310-win32.whl", hash = "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232", size = 209343, upload-time = "2024-08-04T19:43:25.121Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/25/af337cc7421eca1c187cc9c315f0a755d48e755d2853715bfe8c418a45fa/coverage-7.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0", size = 210136, upload-time = "2024-08-04T19:43:26.851Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/5f/67af7d60d7e8ce61a4e2ddcd1bd5fb787180c8d0ae0fbd073f903b3dd95d/coverage-7.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93", size = 206796, upload-time = "2024-08-04T19:43:29.115Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/0e/e52332389e057daa2e03be1fbfef25bb4d626b37d12ed42ae6281d0a274c/coverage-7.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3", size = 207244, upload-time = "2024-08-04T19:43:31.285Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/cd/766b45fb6e090f20f8927d9c7cb34237d41c73a939358bc881883fd3a40d/coverage-7.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff", size = 239279, upload-time = "2024-08-04T19:43:33.581Z" },
-    { url = "https://files.pythonhosted.org/packages/70/6c/a9ccd6fe50ddaf13442a1e2dd519ca805cbe0f1fcd377fba6d8339b98ccb/coverage-7.6.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d", size = 236859, upload-time = "2024-08-04T19:43:35.301Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/8351b465febb4dbc1ca9929505202db909c5a635c6fdf33e089bbc3d7d85/coverage-7.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6", size = 238549, upload-time = "2024-08-04T19:43:37.578Z" },
-    { url = "https://files.pythonhosted.org/packages/68/3c/289b81fa18ad72138e6d78c4c11a82b5378a312c0e467e2f6b495c260907/coverage-7.6.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56", size = 237477, upload-time = "2024-08-04T19:43:39.92Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1c/aa1efa6459d822bd72c4abc0b9418cf268de3f60eeccd65dc4988553bd8d/coverage-7.6.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234", size = 236134, upload-time = "2024-08-04T19:43:41.453Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c8/521c698f2d2796565fe9c789c2ee1ccdae610b3aa20b9b2ef980cc253640/coverage-7.6.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133", size = 236910, upload-time = "2024-08-04T19:43:43.037Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/30/033e663399ff17dca90d793ee8a2ea2890e7fdf085da58d82468b4220bf7/coverage-7.6.1-cp311-cp311-win32.whl", hash = "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c", size = 209348, upload-time = "2024-08-04T19:43:44.787Z" },
-    { url = "https://files.pythonhosted.org/packages/20/05/0d1ccbb52727ccdadaa3ff37e4d2dc1cd4d47f0c3df9eb58d9ec8508ca88/coverage-7.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6", size = 210230, upload-time = "2024-08-04T19:43:46.707Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/d4/300fc921dff243cd518c7db3a4c614b7e4b2431b0d1145c1e274fd99bd70/coverage-7.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778", size = 206983, upload-time = "2024-08-04T19:43:49.082Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ab/6bf00de5327ecb8db205f9ae596885417a31535eeda6e7b99463108782e1/coverage-7.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391", size = 207221, upload-time = "2024-08-04T19:43:52.15Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8f/2ead05e735022d1a7f3a0a683ac7f737de14850395a826192f0288703472/coverage-7.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8", size = 240342, upload-time = "2024-08-04T19:43:53.746Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ef/94043e478201ffa85b8ae2d2c79b4081e5a1b73438aafafccf3e9bafb6b5/coverage-7.6.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d", size = 237371, upload-time = "2024-08-04T19:43:55.993Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0f/c890339dd605f3ebc269543247bdd43b703cce6825b5ed42ff5f2d6122c7/coverage-7.6.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca", size = 239455, upload-time = "2024-08-04T19:43:57.618Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/04/7fd7b39ec7372a04efb0f70c70e35857a99b6a9188b5205efb4c77d6a57a/coverage-7.6.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163", size = 238924, upload-time = "2024-08-04T19:44:00.012Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/bf/73ce346a9d32a09cf369f14d2a06651329c984e106f5992c89579d25b27e/coverage-7.6.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a", size = 237252, upload-time = "2024-08-04T19:44:01.713Z" },
-    { url = "https://files.pythonhosted.org/packages/86/74/1dc7a20969725e917b1e07fe71a955eb34bc606b938316bcc799f228374b/coverage-7.6.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d", size = 238897, upload-time = "2024-08-04T19:44:03.898Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e9/d9cc3deceb361c491b81005c668578b0dfa51eed02cd081620e9a62f24ec/coverage-7.6.1-cp312-cp312-win32.whl", hash = "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5", size = 209606, upload-time = "2024-08-04T19:44:05.532Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c8/5a2e41922ea6740f77d555c4d47544acd7dc3f251fe14199c09c0f5958d3/coverage-7.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb", size = 210373, upload-time = "2024-08-04T19:44:07.079Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/f9/9aa4dfb751cb01c949c990d136a0f92027fbcc5781c6e921df1cb1563f20/coverage-7.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a4acd025ecc06185ba2b801f2de85546e0b8ac787cf9d3b06e7e2a69f925b106", size = 207007, upload-time = "2024-08-04T19:44:09.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/67/e1413d5a8591622a46dd04ff80873b04c849268831ed5c304c16433e7e30/coverage-7.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9", size = 207269, upload-time = "2024-08-04T19:44:11.045Z" },
-    { url = "https://files.pythonhosted.org/packages/14/5b/9dec847b305e44a5634d0fb8498d135ab1d88330482b74065fcec0622224/coverage-7.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c", size = 239886, upload-time = "2024-08-04T19:44:12.83Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/b7/35760a67c168e29f454928f51f970342d23cf75a2bb0323e0f07334c85f3/coverage-7.6.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e81d7a3e58882450ec4186ca59a3f20a5d4440f25b1cff6f0902ad890e6748a", size = 237037, upload-time = "2024-08-04T19:44:15.393Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/95/d2fd31f1d638df806cae59d7daea5abf2b15b5234016a5ebb502c2f3f7ee/coverage-7.6.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060", size = 239038, upload-time = "2024-08-04T19:44:17.466Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/bd/110689ff5752b67924efd5e2aedf5190cbbe245fc81b8dec1abaffba619d/coverage-7.6.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a78d169acd38300060b28d600344a803628c3fd585c912cacc9ea8790fe96862", size = 238690, upload-time = "2024-08-04T19:44:19.336Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/a8/08d7b38e6ff8df52331c83130d0ab92d9c9a8b5462f9e99c9f051a4ae206/coverage-7.6.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c09f4ce52cb99dd7505cd0fc8e0e37c77b87f46bc9c1eb03fe3bc9991085388", size = 236765, upload-time = "2024-08-04T19:44:20.994Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/6a/9cf96839d3147d55ae713eb2d877f4d777e7dc5ba2bce227167d0118dfe8/coverage-7.6.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6878ef48d4227aace338d88c48738a4258213cd7b74fd9a3d4d7582bb1d8a155", size = 238611, upload-time = "2024-08-04T19:44:22.616Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e4/7ff20d6a0b59eeaab40b3140a71e38cf52547ba21dbcf1d79c5a32bba61b/coverage-7.6.1-cp313-cp313-win32.whl", hash = "sha256:44df346d5215a8c0e360307d46ffaabe0f5d3502c8a1cefd700b34baf31d411a", size = 209671, upload-time = "2024-08-04T19:44:24.418Z" },
-    { url = "https://files.pythonhosted.org/packages/35/59/1812f08a85b57c9fdb6d0b383d779e47b6f643bc278ed682859512517e83/coverage-7.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:8284cf8c0dd272a247bc154eb6c95548722dce90d098c17a883ed36e67cdb129", size = 210368, upload-time = "2024-08-04T19:44:26.276Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/15/08913be1c59d7562a3e39fce20661a98c0a3f59d5754312899acc6cb8a2d/coverage-7.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d3296782ca4eab572a1a4eca686d8bfb00226300dcefdf43faa25b5242ab8a3e", size = 207758, upload-time = "2024-08-04T19:44:29.028Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ae/b5d58dff26cade02ada6ca612a76447acd69dccdbb3a478e9e088eb3d4b9/coverage-7.6.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962", size = 208035, upload-time = "2024-08-04T19:44:30.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d7/62095e355ec0613b08dfb19206ce3033a0eedb6f4a67af5ed267a8800642/coverage-7.6.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb", size = 250839, upload-time = "2024-08-04T19:44:32.412Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/1e/c2967cb7991b112ba3766df0d9c21de46b476d103e32bb401b1b2adf3380/coverage-7.6.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a318d68e92e80af8b00fa99609796fdbcdfef3629c77c6283566c6f02c6d6704", size = 246569, upload-time = "2024-08-04T19:44:34.547Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/61/a7a6a55dd266007ed3b1df7a3386a0d760d014542d72f7c2c6938483b7bd/coverage-7.6.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b", size = 248927, upload-time = "2024-08-04T19:44:36.313Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/fa/13a6f56d72b429f56ef612eb3bc5ce1b75b7ee12864b3bd12526ab794847/coverage-7.6.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4421712dbfc5562150f7554f13dde997a2e932a6b5f352edcce948a815efee6f", size = 248401, upload-time = "2024-08-04T19:44:38.155Z" },
-    { url = "https://files.pythonhosted.org/packages/75/06/0429c652aa0fb761fc60e8c6b291338c9173c6aa0f4e40e1902345b42830/coverage-7.6.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:166811d20dfea725e2e4baa71fffd6c968a958577848d2131f39b60043400223", size = 246301, upload-time = "2024-08-04T19:44:39.883Z" },
-    { url = "https://files.pythonhosted.org/packages/52/76/1766bb8b803a88f93c3a2d07e30ffa359467810e5cbc68e375ebe6906efb/coverage-7.6.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:225667980479a17db1048cb2bf8bfb39b8e5be8f164b8f6628b64f78a72cf9d3", size = 247598, upload-time = "2024-08-04T19:44:41.59Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8b/f54f8db2ae17188be9566e8166ac6df105c1c611e25da755738025708d54/coverage-7.6.1-cp313-cp313t-win32.whl", hash = "sha256:170d444ab405852903b7d04ea9ae9b98f98ab6d7e63e1115e82620807519797f", size = 210307, upload-time = "2024-08-04T19:44:43.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/b0/e0dca6da9170aefc07515cce067b97178cefafb512d00a87a1c717d2efd5/coverage-7.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b9f222de8cded79c49bf184bdbc06630d4c58eec9459b939b4a690c82ed05657", size = 211453, upload-time = "2024-08-04T19:44:45.677Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d0/d9e3d554e38beea5a2e22178ddb16587dbcbe9a1ef3211f55733924bf7fa/coverage-7.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0", size = 206674, upload-time = "2024-08-04T19:44:47.694Z" },
-    { url = "https://files.pythonhosted.org/packages/38/ea/cab2dc248d9f45b2b7f9f1f596a4d75a435cb364437c61b51d2eb33ceb0e/coverage-7.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a", size = 207101, upload-time = "2024-08-04T19:44:49.32Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6f/f82f9a500c7c5722368978a5390c418d2a4d083ef955309a8748ecaa8920/coverage-7.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b", size = 236554, upload-time = "2024-08-04T19:44:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/94/d3055aa33d4e7e733d8fa309d9adf147b4b06a82c1346366fc15a2b1d5fa/coverage-7.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b43c03669dc4618ec25270b06ecd3ee4fa94c7f9b3c14bae6571ca00ef98b0d3", size = 234440, upload-time = "2024-08-04T19:44:53.464Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6e/885bcd787d9dd674de4a7d8ec83faf729534c63d05d51d45d4fa168f7102/coverage-7.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de", size = 235889, upload-time = "2024-08-04T19:44:55.165Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/63/df50120a7744492710854860783d6819ff23e482dee15462c9a833cc428a/coverage-7.6.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:a09ece4a69cf399510c8ab25e0950d9cf2b42f7b3cb0374f95d2e2ff594478a6", size = 235142, upload-time = "2024-08-04T19:44:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5d/9d0acfcded2b3e9ce1c7923ca52ccc00c78a74e112fc2aee661125b7843b/coverage-7.6.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:9054a0754de38d9dbd01a46621636689124d666bad1936d76c0341f7d71bf569", size = 233805, upload-time = "2024-08-04T19:44:59.033Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/56/50abf070cb3cd9b1dd32f2c88f083aab561ecbffbcd783275cb51c17f11d/coverage-7.6.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0dbde0f4aa9a16fa4d754356a8f2e36296ff4d83994b2c9d8398aa32f222f989", size = 234655, upload-time = "2024-08-04T19:45:01.398Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ee/b4c246048b8485f85a2426ef4abab88e48c6e80c74e964bea5cd4cd4b115/coverage-7.6.1-cp38-cp38-win32.whl", hash = "sha256:da511e6ad4f7323ee5702e6633085fb76c2f893aaf8ce4c51a0ba4fc07580ea7", size = 209296, upload-time = "2024-08-04T19:45:03.819Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/1c/96cf86b70b69ea2b12924cdf7cabb8ad10e6130eab8d767a1099fbd2a44f/coverage-7.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:3f1156e3e8f2872197af3840d8ad307a9dd18e615dc64d9ee41696f287c57ad8", size = 210137, upload-time = "2024-08-04T19:45:06.25Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d3/d54c5aa83268779d54c86deb39c1c4566e5d45c155369ca152765f8db413/coverage-7.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255", size = 206688, upload-time = "2024-08-04T19:45:08.358Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/fe/137d5dca72e4a258b1bc17bb04f2e0196898fe495843402ce826a7419fe3/coverage-7.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8", size = 207120, upload-time = "2024-08-04T19:45:11.526Z" },
-    { url = "https://files.pythonhosted.org/packages/78/5b/a0a796983f3201ff5485323b225d7c8b74ce30c11f456017e23d8e8d1945/coverage-7.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2", size = 235249, upload-time = "2024-08-04T19:45:13.202Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/e1/76089d6a5ef9d68f018f65411fcdaaeb0141b504587b901d74e8587606ad/coverage-7.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a", size = 233237, upload-time = "2024-08-04T19:45:14.961Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/eef79b779a540326fee9520e5542a8b428cc3bfa8b7c8f1022c1ee4fc66c/coverage-7.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc", size = 234311, upload-time = "2024-08-04T19:45:16.924Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e1/656d65fb126c29a494ef964005702b012f3498db1a30dd562958e85a4049/coverage-7.6.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004", size = 233453, upload-time = "2024-08-04T19:45:18.672Z" },
-    { url = "https://files.pythonhosted.org/packages/68/6a/45f108f137941a4a1238c85f28fd9d048cc46b5466d6b8dda3aba1bb9d4f/coverage-7.6.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb", size = 231958, upload-time = "2024-08-04T19:45:20.63Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e7/47b809099168b8b8c72ae311efc3e88c8d8a1162b3ba4b8da3cfcdb85743/coverage-7.6.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36", size = 232938, upload-time = "2024-08-04T19:45:23.062Z" },
-    { url = "https://files.pythonhosted.org/packages/52/80/052222ba7058071f905435bad0ba392cc12006380731c37afaf3fe749b88/coverage-7.6.1-cp39-cp39-win32.whl", hash = "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c", size = 209352, upload-time = "2024-08-04T19:45:25.042Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d8/1b92e0b3adcf384e98770a00ca095da1b5f7b483e6563ae4eb5e935d24a1/coverage-7.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca", size = 210153, upload-time = "2024-08-04T19:45:27.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/2b/0354ed096bca64dc8e32a7cbcae28b34cb5ad0b1fe2125d6d99583313ac0/coverage-7.6.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df", size = 198926, upload-time = "2024-08-04T19:45:28.875Z" },
-]
-
-[package.optional-dependencies]
-toml = [
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-]
-
-[[package]]
-name = "coverage"
 version = "7.8.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/ba/07/998afa4a0ecdf9b1981ae05415dad2d4e7716e1b1f00abbd91691ac09ac9/coverage-7.8.2.tar.gz", hash = "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27", size = 812759, upload-time = "2025-05-23T11:39:57.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/6b/7dd06399a5c0b81007e3a6af0395cd60e6a30f959f8d407d3ee04642e896/coverage-7.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bd8ec21e1443fd7a447881332f7ce9d35b8fbd2849e761bb290b584535636b0a", size = 211573, upload-time = "2025-05-23T11:37:47.207Z" },
@@ -450,23 +246,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/63/2d624ac7d7ccd4ebbd3c6a9eba9d7fc4491a1226071360d59dd84928ccb2/coverage-7.8.2-cp313-cp313t-win32.whl", hash = "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8", size = 215109, upload-time = "2025-05-23T11:39:26.722Z" },
     { url = "https://files.pythonhosted.org/packages/22/5e/7053b71462e970e869111c1853afd642212568a350eba796deefdfbd0770/coverage-7.8.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d", size = 216268, upload-time = "2025-05-23T11:39:28.429Z" },
     { url = "https://files.pythonhosted.org/packages/07/69/afa41aa34147655543dbe96994f8a246daf94b361ccf5edfd5df62ce066a/coverage-7.8.2-cp313-cp313t-win_arm64.whl", hash = "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b", size = 214071, upload-time = "2025-05-23T11:39:30.55Z" },
-    { url = "https://files.pythonhosted.org/packages/71/1e/388267ad9c6aa126438acc1ceafede3bb746afa9872e3ec5f0691b7d5efa/coverage-7.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:496948261eaac5ac9cf43f5d0a9f6eb7a6d4cb3bedb2c5d294138142f5c18f2a", size = 211566, upload-time = "2025-05-23T11:39:32.333Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a5/acc03e5cf0bba6357f5e7c676343de40fbf431bb1e115fbebf24b2f7f65e/coverage-7.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eacd2de0d30871eff893bab0b67840a96445edcb3c8fd915e6b11ac4b2f3fa6d", size = 211996, upload-time = "2025-05-23T11:39:34.512Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/a2/0fc0a9f6b7c24fa4f1d7210d782c38cb0d5e692666c36eaeae9a441b6755/coverage-7.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b039ffddc99ad65d5078ef300e0c7eed08c270dc26570440e3ef18beb816c1ca", size = 240741, upload-time = "2025-05-23T11:39:36.252Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/da/1c6ba2cf259710eed8916d4fd201dccc6be7380ad2b3b9f63ece3285d809/coverage-7.8.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e49824808d4375ede9dd84e9961a59c47f9113039f1a525e6be170aa4f5c34d", size = 238672, upload-time = "2025-05-23T11:39:38.03Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/51/c8fae0dc3ca421e6e2509503696f910ff333258db672800c3bdef256265a/coverage-7.8.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b069938961dfad881dc2f8d02b47645cd2f455d3809ba92a8a687bf513839787", size = 239769, upload-time = "2025-05-23T11:39:40.24Z" },
-    { url = "https://files.pythonhosted.org/packages/59/8e/b97042ae92c59f40be0c989df090027377ba53f2d6cef73c9ca7685c26a6/coverage-7.8.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:de77c3ba8bb686d1c411e78ee1b97e6e0b963fb98b1637658dd9ad2c875cf9d7", size = 239555, upload-time = "2025-05-23T11:39:42.3Z" },
-    { url = "https://files.pythonhosted.org/packages/47/35/b8893e682d6e96b1db2af5997fc13ef62219426fb17259d6844c693c5e00/coverage-7.8.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1676628065a498943bd3f64f099bb573e08cf1bc6088bbe33cf4424e0876f4b3", size = 237768, upload-time = "2025-05-23T11:39:44.069Z" },
-    { url = "https://files.pythonhosted.org/packages/03/6c/023b0b9a764cb52d6243a4591dcb53c4caf4d7340445113a1f452bb80591/coverage-7.8.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8e1a26e7e50076e35f7afafde570ca2b4d7900a491174ca357d29dece5aacee7", size = 238757, upload-time = "2025-05-23T11:39:46.195Z" },
-    { url = "https://files.pythonhosted.org/packages/03/ed/3af7e4d721bd61a8df7de6de9e8a4271e67f3d9e086454558fd9f48eb4f6/coverage-7.8.2-cp39-cp39-win32.whl", hash = "sha256:6782a12bf76fa61ad9350d5a6ef5f3f020b57f5e6305cbc663803f2ebd0f270a", size = 214166, upload-time = "2025-05-23T11:39:47.934Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/30/ee774b626773750dc6128354884652507df3c59d6aa8431526107e595227/coverage-7.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:1efa4166ba75ccefd647f2d78b64f53f14fb82622bc94c5a5cb0a622f50f1c9e", size = 215050, upload-time = "2025-05-23T11:39:50.252Z" },
     { url = "https://files.pythonhosted.org/packages/69/2f/572b29496d8234e4a7773200dd835a0d32d9e171f2d974f3fe04a9dbc271/coverage-7.8.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837", size = 203636, upload-time = "2025-05-23T11:39:52.002Z" },
     { url = "https://files.pythonhosted.org/packages/a0/1a/0b9c32220ad694d66062f571cc5cedfa9997b64a591e8a500bb63de1bd40/coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32", size = 203623, upload-time = "2025-05-23T11:39:53.846Z" },
 ]
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -504,30 +290,10 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "astunparse", marker = "python_full_version < '3.9'" },
-    { name = "colorama", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/e9/b2c86ad9d69053e497a24ceb25d661094fb321ab4ed39a8b71793dcbae82/griffe-1.4.0.tar.gz", hash = "sha256:8fccc585896d13f1221035d32c50dec65830c87d23f9adb9b1e6f3d63574f7f5", size = 381028, upload-time = "2024-10-11T12:53:54.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/7c/e9e66869c2e4c9b378474e49c993128ec0131ef4721038b6d06e50538caf/griffe-1.4.0-py3-none-any.whl", hash = "sha256:e589de8b8c137e99a46ec45f9598fc0ac5b6868ce824b24db09c02d117b89bc5", size = 127015, upload-time = "2024-10-11T12:53:52.383Z" },
-]
-
-[[package]]
-name = "griffe"
 version = "1.7.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.9'" },
+    { name = "colorama" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/3e/5aa9a61f7c3c47b0b52a1d930302992229d191bf4bc76447b324b731510a/griffe-1.7.3.tar.gz", hash = "sha256:52ee893c6a3a968b639ace8015bec9d36594961e156e23315c8e8e51401fa50b", size = 395137, upload-time = "2025-04-23T11:29:09.147Z" }
 wheels = [
@@ -544,36 +310,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "zipp", version = "3.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304, upload-time = "2024-09-11T14:56:08.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514, upload-time = "2024-09-11T14:56:07.019Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-]
-dependencies = [
-    { name = "zipp", version = "3.21.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -587,8 +323,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markupsafe", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -610,30 +345,8 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.7"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2", size = 357086, upload-time = "2024-08-16T15:55:17.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803", size = 106349, upload-time = "2024-08-16T15:55:16.176Z" },
-]
-
-[[package]]
-name = "markdown"
 version = "3.8"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
-dependencies = [
-    { name = "importlib-metadata", version = "8.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/15/222b423b0b88689c266d9eac4e61396fe2cc53464459d6a37618ac863b24/markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f", size = 360906, upload-time = "2025-04-11T14:42:50.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc", size = 106210, upload-time = "2025-04-11T14:42:49.178Z" },
@@ -653,73 +366,8 @@ wheels = [
 
 [[package]]
 name = "markupsafe"
-version = "2.1.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384, upload-time = "2024-02-02T16:31:22.863Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206, upload-time = "2024-02-02T16:30:04.105Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/4a/a4d49415e600bacae038c67f9fecc1d5433b9d3c71a4de6f33537b89654c/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5", size = 14079, upload-time = "2024-02-02T16:30:06.5Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46", size = 26620, upload-time = "2024-02-02T16:30:08.31Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f", size = 25818, upload-time = "2024-02-02T16:30:09.577Z" },
-    { url = "https://files.pythonhosted.org/packages/29/fe/a36ba8c7ca55621620b2d7c585313efd10729e63ef81e4e61f52330da781/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900", size = 25493, upload-time = "2024-02-02T16:30:11.488Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ae/9c60231cdfda003434e8bd27282b1f4e197ad5a710c14bee8bea8a9ca4f0/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff", size = 30630, upload-time = "2024-02-02T16:30:13.144Z" },
-    { url = "https://files.pythonhosted.org/packages/65/dc/1510be4d179869f5dafe071aecb3f1f41b45d37c02329dfba01ff59e5ac5/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad", size = 29745, upload-time = "2024-02-02T16:30:14.222Z" },
-    { url = "https://files.pythonhosted.org/packages/30/39/8d845dd7d0b0613d86e0ef89549bfb5f61ed781f59af45fc96496e897f3a/MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd", size = 30021, upload-time = "2024-02-02T16:30:16.032Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5c/356a6f62e4f3c5fbf2602b4771376af22a3b16efa74eb8716fb4e328e01e/MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4", size = 16659, upload-time = "2024-02-02T16:30:17.079Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/acbf292615c65f0604a0c6fc402ce6d8c991276e16c80c46a8f758fbd30c/MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5", size = 17213, upload-time = "2024-02-02T16:30:18.251Z" },
-    { url = "https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f", size = 18219, upload-time = "2024-02-02T16:30:19.988Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2", size = 14098, upload-time = "2024-02-02T16:30:21.063Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/cf/35fe557e53709e93feb65575c93927942087e9b97213eabc3fe9d5b25a55/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced", size = 29014, upload-time = "2024-02-02T16:30:22.926Z" },
-    { url = "https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5", size = 28220, upload-time = "2024-02-02T16:30:24.76Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/40/2e73e7d532d030b1e41180807a80d564eda53babaf04d65e15c1cf897e40/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c", size = 27756, upload-time = "2024-02-02T16:30:25.877Z" },
-    { url = "https://files.pythonhosted.org/packages/18/46/5dca760547e8c59c5311b332f70605d24c99d1303dd9a6e1fc3ed0d73561/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f", size = 33988, upload-time = "2024-02-02T16:30:26.935Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c5/27febe918ac36397919cd4a67d5579cbbfa8da027fa1238af6285bb368ea/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a", size = 32718, upload-time = "2024-02-02T16:30:28.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/81/56e567126a2c2bc2684d6391332e357589a96a76cb9f8e5052d85cb0ead8/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f", size = 33317, upload-time = "2024-02-02T16:30:29.214Z" },
-    { url = "https://files.pythonhosted.org/packages/00/0b/23f4b2470accb53285c613a3ab9ec19dc944eaf53592cb6d9e2af8aa24cc/MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906", size = 16670, upload-time = "2024-02-02T16:30:30.915Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a2/c78a06a9ec6d04b3445a949615c4c7ed86a0b2eb68e44e7541b9d57067cc/MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617", size = 17224, upload-time = "2024-02-02T16:30:32.09Z" },
-    { url = "https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1", size = 18215, upload-time = "2024-02-02T16:30:33.081Z" },
-    { url = "https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4", size = 14069, upload-time = "2024-02-02T16:30:34.148Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b5/5d8ec796e2a08fc814a2c7d2584b55f889a55cf17dd1a90f2beb70744e5c/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee", size = 29452, upload-time = "2024-02-02T16:30:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5", size = 28462, upload-time = "2024-02-02T16:30:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/75/fd6cb2e68780f72d47e6671840ca517bda5ef663d30ada7616b0462ad1e3/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b", size = 27869, upload-time = "2024-02-02T16:30:37.834Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/81/147c477391c2750e8fc7705829f7351cf1cd3be64406edcf900dc633feb2/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a", size = 33906, upload-time = "2024-02-02T16:30:39.366Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ff/9a52b71839d7a256b563e85d11050e307121000dcebc97df120176b3ad93/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f", size = 32296, upload-time = "2024-02-02T16:30:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038, upload-time = "2024-02-02T16:30:42.243Z" },
-    { url = "https://files.pythonhosted.org/packages/96/0c/620c1fb3661858c0e37eb3cbffd8c6f732a67cd97296f725789679801b31/MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad", size = 16572, upload-time = "2024-02-02T16:30:43.326Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb", size = 17127, upload-time = "2024-02-02T16:30:44.418Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ff/2c942a82c35a49df5de3a630ce0a8456ac2969691b230e530ac12314364c/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a", size = 18192, upload-time = "2024-02-02T16:30:57.715Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/14/6f294b9c4f969d0c801a4615e221c1e084722ea6114ab2114189c5b8cbe0/MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46", size = 14072, upload-time = "2024-02-02T16:30:58.844Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d4/fd74714ed30a1dedd0b82427c02fa4deec64f173831ec716da11c51a50aa/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532", size = 26928, upload-time = "2024-02-02T16:30:59.922Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/bd/50319665ce81bb10e90d1cf76f9e1aa269ea6f7fa30ab4521f14d122a3df/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab", size = 26106, upload-time = "2024-02-02T16:31:01.582Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/6f/f2b0f675635b05f6afd5ea03c094557bdb8622fa8e673387444fe8d8e787/MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68", size = 25781, upload-time = "2024-02-02T16:31:02.71Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e0/393467cf899b34a9d3678e78961c2c8cdf49fb902a959ba54ece01273fb1/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0", size = 30518, upload-time = "2024-02-02T16:31:04.392Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/02/5437e2ad33047290dafced9df741d9efc3e716b75583bbd73a9984f1b6f7/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4", size = 29669, upload-time = "2024-02-02T16:31:05.53Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/7d/968284145ffd9d726183ed6237c77938c021abacde4e073020f920e060b2/MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3", size = 29933, upload-time = "2024-02-02T16:31:06.636Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/f3/ecb00fc8ab02b7beae8699f34db9357ae49d9f21d4d3de6f305f34fa949e/MarkupSafe-2.1.5-cp38-cp38-win32.whl", hash = "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff", size = 16656, upload-time = "2024-02-02T16:31:07.767Z" },
-    { url = "https://files.pythonhosted.org/packages/92/21/357205f03514a49b293e214ac39de01fadd0970a6e05e4bf1ddd0ffd0881/MarkupSafe-2.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029", size = 17206, upload-time = "2024-02-02T16:31:08.843Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/31/780bb297db036ba7b7bbede5e1d7f1e14d704ad4beb3ce53fb495d22bc62/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf", size = 18193, upload-time = "2024-02-02T16:31:10.155Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d77701bbef72892affe060cdacb7a2ed7fd68dae3b477a8642f15ad3b132/MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2", size = 14073, upload-time = "2024-02-02T16:31:11.442Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a7/1e558b4f78454c8a3a0199292d96159eb4d091f983bc35ef258314fe7269/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8", size = 26486, upload-time = "2024-02-02T16:31:12.488Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5a/360da85076688755ea0cceb92472923086993e86b5613bbae9fbc14136b0/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3", size = 25685, upload-time = "2024-02-02T16:31:13.726Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/18/ae5a258e3401f9b8312f92b028c54d7026a97ec3ab20bfaddbdfa7d8cce8/MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465", size = 25338, upload-time = "2024-02-02T16:31:14.812Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/cc/48206bd61c5b9d0129f4d75243b156929b04c94c09041321456fd06a876d/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e", size = 30439, upload-time = "2024-02-02T16:31:15.946Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/06/a41c112ab9ffdeeb5f77bc3e331fdadf97fa65e52e44ba31880f4e7f983c/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea", size = 29531, upload-time = "2024-02-02T16:31:17.13Z" },
-    { url = "https://files.pythonhosted.org/packages/02/8c/ab9a463301a50dab04d5472e998acbd4080597abc048166ded5c7aa768c8/MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6", size = 29823, upload-time = "2024-02-02T16:31:18.247Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/29/9bc18da763496b055d8e98ce476c8e718dcfd78157e17f555ce6dd7d0895/MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf", size = 16658, upload-time = "2024-02-02T16:31:19.583Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f8/4da07de16f10551ca1f640c92b5f316f9394088b183c6a57183df6de5ae4/MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5", size = 17211, upload-time = "2024-02-02T16:31:20.96Z" },
-]
-
-[[package]]
-name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
@@ -772,16 +420,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ea/9b1530c3fdeeca613faeb0fb5cbcf2389d816072fab72a71b45749ef6062/MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a", size = 14344, upload-time = "2024-10-18T15:21:43.721Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/c2/fbdbfe48848e7112ab05e627e718e854d20192b674952d9042ebd8c9e5de/MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff", size = 12389, upload-time = "2024-10-18T15:21:44.666Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/25/7a7c6e4dbd4f867d95d94ca15449e91e52856f6ed1905d58ef1de5e211d0/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13", size = 21607, upload-time = "2024-10-18T15:21:45.452Z" },
-    { url = "https://files.pythonhosted.org/packages/53/8f/f339c98a178f3c1e545622206b40986a4c3307fe39f70ccd3d9df9a9e425/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144", size = 20728, upload-time = "2024-10-18T15:21:46.295Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/03/8496a1a78308456dbd50b23a385c69b41f2e9661c67ea1329849a598a8f9/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29", size = 20826, upload-time = "2024-10-18T15:21:47.134Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/cf/0a490a4bd363048c3022f2f475c8c05582179bb179defcee4766fb3dcc18/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0", size = 21843, upload-time = "2024-10-18T15:21:48.334Z" },
-    { url = "https://files.pythonhosted.org/packages/19/a3/34187a78613920dfd3cdf68ef6ce5e99c4f3417f035694074beb8848cd77/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0", size = 21219, upload-time = "2024-10-18T15:21:49.587Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d8/5811082f85bb88410ad7e452263af048d685669bbbfb7b595e8689152498/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178", size = 20946, upload-time = "2024-10-18T15:21:50.441Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/31/bd635fb5989440d9365c5e3c47556cfea121c7803f5034ac843e8f37c2f2/MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f", size = 15063, upload-time = "2024-10-18T15:21:51.385Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/73/085399401383ce949f727afec55ec3abd76648d04b9f22e1c0e99cb4bec3/MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a", size = 15506, upload-time = "2024-10-18T15:21:52.974Z" },
 ]
 
 [[package]]
@@ -830,26 +468,19 @@ name = "mkdocs"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "jinja2" },
-    { name = "markdown", version = "3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markdown", version = "3.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markupsafe", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "markdown" },
+    { name = "markupsafe" },
     { name = "mergedeep" },
     { name = "mkdocs-get-deps" },
     { name = "packaging" },
     { name = "pathspec" },
     { name = "pyyaml" },
-    { name = "pyyaml-env-tag", version = "0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pyyaml-env-tag", version = "1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "watchdog", version = "4.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "watchdog", version = "6.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
 wheels = [
@@ -858,33 +489,12 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "markdown", version = "3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mkdocs", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/ae/0f1154c614d6a8b8a36fff084e5b82af3a15f7d2060cf0dcdb1c53297a71/mkdocs_autorefs-1.2.0.tar.gz", hash = "sha256:a86b93abff653521bda71cf3fc5596342b7a23982093915cb74273f67522190f", size = 40262, upload-time = "2024-09-01T18:29:18.514Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/26/4d39d52ea2219604053a4d05b98e90d6a335511cc01806436ec4886b1028/mkdocs_autorefs-1.2.0-py3-none-any.whl", hash = "sha256:d588754ae89bd0ced0c70c06f58566a4ee43471eeeee5202427da7de9ef85a2f", size = 16522, upload-time = "2024-09-01T18:29:16.605Z" },
-]
-
-[[package]]
-name = "mkdocs-autorefs"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "markdown", version = "3.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "markupsafe", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "mkdocs", marker = "python_full_version >= '3.9'" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/0c/c9826f35b99c67fa3a7cddfa094c1a6c43fafde558c309c6e4403e5b37dc/mkdocs_autorefs-1.4.2.tar.gz", hash = "sha256:e2ebe1abd2b67d597ed19378c0fff84d73d1dbce411fce7a7cc6f161888b6749", size = 54961, upload-time = "2025-05-20T13:09:09.886Z" }
 wheels = [
@@ -896,11 +506,8 @@ name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "mergedeep" },
-    { name = "platformdirs", version = "4.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "platformdirs", version = "4.3.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "platformdirs" },
     { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
@@ -914,12 +521,10 @@ version = "9.6.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
-    { name = "backrefs", version = "5.7.post1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "backrefs", version = "5.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "backrefs" },
     { name = "colorama" },
     { name = "jinja2" },
-    { name = "markdown", version = "3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markdown", version = "3.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "markdown" },
     { name = "mkdocs" },
     { name = "mkdocs-material-extensions" },
     { name = "paginate" },
@@ -951,8 +556,7 @@ dependencies = [
     { name = "mkdocs" },
     { name = "pymdown-extensions" },
     { name = "requests" },
-    { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "setuptools", version = "80.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "setuptools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/1a/f580733da1924ebc9b4bb04a34ca63ae62a50b0e62eeb016e78d9dee6d69/mkdocs_mermaid2_plugin-1.2.1.tar.gz", hash = "sha256:9c7694c73a65905ac1578f966e5c193325c4d5a5bc1836727e74ac9f99d0e921", size = 16104, upload-time = "2024-11-02T06:27:36.302Z" }
 wheels = [
@@ -961,44 +565,15 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "0.26.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "jinja2", marker = "python_full_version < '3.9'" },
-    { name = "markdown", version = "3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markupsafe", version = "2.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mkdocs", marker = "python_full_version < '3.9'" },
-    { name = "mkdocs-autorefs", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "platformdirs", version = "4.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pymdown-extensions", marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/170ff04de72227f715d67da32950c7b8434449f3805b2ec3dd1085db4d7c/mkdocstrings-0.26.1.tar.gz", hash = "sha256:bb8b8854d6713d5348ad05b069a09f3b79edbc6a0f33a34c6821141adb03fe33", size = 92677, upload-time = "2024-09-06T10:26:06.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/cc/8ba127aaee5d1e9046b0d33fa5b3d17da95a9d705d44902792e0569257fd/mkdocstrings-0.26.1-py3-none-any.whl", hash = "sha256:29738bfb72b4608e8e55cc50fb8a54f325dc7ebd2014e4e3881a49892d5983cf", size = 29643, upload-time = "2024-09-06T10:26:04.498Z" },
-]
-
-[[package]]
-name = "mkdocstrings"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "importlib-metadata", version = "8.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "jinja2", marker = "python_full_version >= '3.9'" },
-    { name = "markdown", version = "3.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "markupsafe", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "mkdocs", marker = "python_full_version >= '3.9'" },
-    { name = "mkdocs-autorefs", version = "1.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pymdown-extensions", marker = "python_full_version >= '3.9'" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/e8/d22922664a627a0d3d7ff4a6ca95800f5dde54f411982591b4621a76225d/mkdocstrings-0.29.1.tar.gz", hash = "sha256:8722f8f8c5cd75da56671e0a0c1bbed1df9946c0cef74794d6141b34011abd42", size = 1212686, upload-time = "2025-03-31T08:33:11.997Z" }
 wheels = [
@@ -1007,34 +582,13 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.11.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "griffe", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mkdocs-autorefs", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mkdocstrings", version = "0.26.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/ba/534c934cd0a809f51c91332d6ed278782ee4126b8ba8db02c2003f162b47/mkdocstrings_python-1.11.1.tar.gz", hash = "sha256:8824b115c5359304ab0b5378a91f6202324a849e1da907a3485b59208b797322", size = 166890, upload-time = "2024-09-03T17:20:54.904Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/f2/2a2c48fda645ac6bbe73bcc974587a579092b6868e6ff8bc6d177f4db38a/mkdocstrings_python-1.11.1-py3-none-any.whl", hash = "sha256:a21a1c05acef129a618517bb5aae3e33114f569b11588b1e7af3e9d4061a71af", size = 109297, upload-time = "2024-09-03T17:20:52.621Z" },
-]
-
-[[package]]
-name = "mkdocstrings-python"
 version = "1.16.11"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "griffe", version = "1.7.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "mkdocs-autorefs", version = "1.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "mkdocstrings", version = "0.29.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+    { name = "griffe" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/a3/0c7559a355fa21127a174a5aa2d3dca2de6e479ddd9c63ca4082d5f9980c/mkdocstrings_python-1.16.11.tar.gz", hash = "sha256:935f95efa887f99178e4a7becaaa1286fb35adafffd669b04fd611d97c00e5ce", size = 205392, upload-time = "2025-05-24T10:41:32.078Z" }
 wheels = [
@@ -1043,69 +597,12 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.14.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version < '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051, upload-time = "2024-12-30T16:39:07.335Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/7a/87ae2adb31d68402da6da1e5f30c07ea6063e9f09b5e7cfc9dfa44075e74/mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb", size = 11211002, upload-time = "2024-12-30T16:37:22.435Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/23/eada4c38608b444618a132be0d199b280049ded278b24cbb9d3fc59658e4/mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0", size = 10358400, upload-time = "2024-12-30T16:37:53.526Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c9/d6785c6f66241c62fd2992b05057f404237deaad1566545e9f144ced07f5/mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d", size = 12095172, upload-time = "2024-12-30T16:37:50.332Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/62/daa7e787770c83c52ce2aaf1a111eae5893de9e004743f51bfcad9e487ec/mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b", size = 12828732, upload-time = "2024-12-30T16:37:29.96Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/a2/5fb18318a3637f29f16f4e41340b795da14f4751ef4f51c99ff39ab62e52/mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427", size = 13012197, upload-time = "2024-12-30T16:38:05.037Z" },
-    { url = "https://files.pythonhosted.org/packages/28/99/e153ce39105d164b5f02c06c35c7ba958aaff50a2babba7d080988b03fe7/mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f", size = 9780836, upload-time = "2024-12-30T16:37:19.726Z" },
-    { url = "https://files.pythonhosted.org/packages/da/11/a9422850fd506edbcdc7f6090682ecceaf1f87b9dd847f9df79942da8506/mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c", size = 11120432, upload-time = "2024-12-30T16:37:11.533Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/9e/47e450fd39078d9c02d620545b2cb37993a8a8bdf7db3652ace2f80521ca/mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1", size = 10279515, upload-time = "2024-12-30T16:37:40.724Z" },
-    { url = "https://files.pythonhosted.org/packages/01/b5/6c8d33bd0f851a7692a8bfe4ee75eb82b6983a3cf39e5e32a5d2a723f0c1/mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8", size = 12025791, upload-time = "2024-12-30T16:36:58.73Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/4c/e10e2c46ea37cab5c471d0ddaaa9a434dc1d28650078ac1b56c2d7b9b2e4/mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f", size = 12749203, upload-time = "2024-12-30T16:37:03.741Z" },
-    { url = "https://files.pythonhosted.org/packages/88/55/beacb0c69beab2153a0f57671ec07861d27d735a0faff135a494cd4f5020/mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1", size = 12885900, upload-time = "2024-12-30T16:37:57.948Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/75/8c93ff7f315c4d086a2dfcde02f713004357d70a163eddb6c56a6a5eff40/mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae", size = 9777869, upload-time = "2024-12-30T16:37:33.428Z" },
-    { url = "https://files.pythonhosted.org/packages/43/1b/b38c079609bb4627905b74fc6a49849835acf68547ac33d8ceb707de5f52/mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14", size = 11266668, upload-time = "2024-12-30T16:38:02.211Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/75/2ed0d2964c1ffc9971c729f7a544e9cd34b2cdabbe2d11afd148d7838aa2/mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9", size = 10254060, upload-time = "2024-12-30T16:37:46.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5f/7b8051552d4da3c51bbe8fcafffd76a6823779101a2b198d80886cd8f08e/mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11", size = 11933167, upload-time = "2024-12-30T16:37:43.534Z" },
-    { url = "https://files.pythonhosted.org/packages/04/90/f53971d3ac39d8b68bbaab9a4c6c58c8caa4d5fd3d587d16f5927eeeabe1/mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e", size = 12864341, upload-time = "2024-12-30T16:37:36.249Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d2/8bc0aeaaf2e88c977db41583559319f1821c069e943ada2701e86d0430b7/mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89", size = 12972991, upload-time = "2024-12-30T16:37:06.743Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/17/07815114b903b49b0f2cf7499f1c130e5aa459411596668267535fe9243c/mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b", size = 9879016, upload-time = "2024-12-30T16:37:15.02Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/15/bb6a686901f59222275ab228453de741185f9d54fecbaacec041679496c6/mypy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255", size = 11252097, upload-time = "2024-12-30T16:37:25.144Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/b3/8b0f74dfd072c802b7fa368829defdf3ee1566ba74c32a2cb2403f68024c/mypy-1.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34", size = 10239728, upload-time = "2024-12-30T16:38:08.634Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/9b/4fd95ab20c52bb5b8c03cc49169be5905d931de17edfe4d9d2986800b52e/mypy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a", size = 11924965, upload-time = "2024-12-30T16:38:12.132Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9d/4a236b9c57f5d8f08ed346914b3f091a62dd7e19336b2b2a0d85485f82ff/mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9", size = 12867660, upload-time = "2024-12-30T16:38:17.342Z" },
-    { url = "https://files.pythonhosted.org/packages/40/88/a61a5497e2f68d9027de2bb139c7bb9abaeb1be1584649fa9d807f80a338/mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd", size = 12969198, upload-time = "2024-12-30T16:38:32.839Z" },
-    { url = "https://files.pythonhosted.org/packages/54/da/3d6fc5d92d324701b0c23fb413c853892bfe0e1dbe06c9138037d459756b/mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107", size = 9885276, upload-time = "2024-12-30T16:38:20.828Z" },
-    { url = "https://files.pythonhosted.org/packages/39/02/1817328c1372be57c16148ce7d2bfcfa4a796bedaed897381b1aad9b267c/mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31", size = 11143050, upload-time = "2024-12-30T16:38:29.743Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/07/99db9a95ece5e58eee1dd87ca456a7e7b5ced6798fd78182c59c35a7587b/mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6", size = 10321087, upload-time = "2024-12-30T16:38:14.739Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/eb/85ea6086227b84bce79b3baf7f465b4732e0785830726ce4a51528173b71/mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319", size = 12066766, upload-time = "2024-12-30T16:38:47.038Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/bb/f01bebf76811475d66359c259eabe40766d2f8ac8b8250d4e224bb6df379/mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac", size = 12787111, upload-time = "2024-12-30T16:39:02.444Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/c9/84837ff891edcb6dcc3c27d85ea52aab0c4a34740ff5f0ccc0eb87c56139/mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b", size = 12974331, upload-time = "2024-12-30T16:38:23.849Z" },
-    { url = "https://files.pythonhosted.org/packages/84/5f/901e18464e6a13f8949b4909535be3fa7f823291b8ab4e4b36cfe57d6769/mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837", size = 9763210, upload-time = "2024-12-30T16:38:36.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/1f/186d133ae2514633f8558e78cd658070ba686c0e9275c5a5c24a1e1f0d67/mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35", size = 11200493, upload-time = "2024-12-30T16:38:26.935Z" },
-    { url = "https://files.pythonhosted.org/packages/af/fc/4842485d034e38a4646cccd1369f6b1ccd7bc86989c52770d75d719a9941/mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc", size = 10357702, upload-time = "2024-12-30T16:38:50.623Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e6/457b83f2d701e23869cfec013a48a12638f75b9d37612a9ddf99072c1051/mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9", size = 12091104, upload-time = "2024-12-30T16:38:53.735Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/bf/76a569158db678fee59f4fd30b8e7a0d75bcbaeef49edd882a0d63af6d66/mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb", size = 12830167, upload-time = "2024-12-30T16:38:56.437Z" },
-    { url = "https://files.pythonhosted.org/packages/43/bc/0bc6b694b3103de9fed61867f1c8bd33336b913d16831431e7cb48ef1c92/mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60", size = 13013834, upload-time = "2024-12-30T16:38:59.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/79/5f5ec47849b6df1e6943d5fd8e6632fbfc04b4fd4acfa5a5a9535d11b4e2/mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c", size = 9781231, upload-time = "2024-12-30T16:39:05.124Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905, upload-time = "2024-12-30T16:38:42.021Z" },
-]
-
-[[package]]
-name = "mypy"
 version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version >= '3.9'" },
-    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.9'" },
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717, upload-time = "2025-02-05T03:50:34.655Z" }
 wheels = [
@@ -1133,12 +630,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541, upload-time = "2025-02-05T03:49:57.623Z" },
     { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348, upload-time = "2025-02-05T03:48:52.361Z" },
     { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648, upload-time = "2025-02-05T03:49:11.395Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/fa/79cf41a55b682794abe71372151dbbf856e3008f6767057229e6649d294a/mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078", size = 10737129, upload-time = "2025-02-05T03:50:24.509Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/33/dd8feb2597d648de29e3da0a8bf4e1afbda472964d2a4a0052203a6f3594/mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba", size = 9856335, upload-time = "2025-02-05T03:49:36.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b5/74508959c1b06b96674b364ffeb7ae5802646b32929b7701fc6b18447592/mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5", size = 11611935, upload-time = "2025-02-05T03:49:14.154Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/53/da61b9d9973efcd6507183fdad96606996191657fe79701b2c818714d573/mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b", size = 12365827, upload-time = "2025-02-05T03:48:59.458Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/72/965bd9ee89540c79a25778cc080c7e6ef40aa1eeac4d52cec7eae6eb5228/mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2", size = 12541924, upload-time = "2025-02-05T03:50:03.12Z" },
-    { url = "https://files.pythonhosted.org/packages/46/d0/f41645c2eb263e6c77ada7d76f894c580c9ddb20d77f0c24d34273a4dab2/mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980", size = 9271176, upload-time = "2025-02-05T03:50:10.86Z" },
     { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777, upload-time = "2025-02-05T03:50:08.348Z" },
 ]
 
@@ -1183,8 +674,7 @@ name = "pbr"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "setuptools", version = "80.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "setuptools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/d2/510cc0d218e753ba62a1bc1434651db3cd797a9716a0a66cc714cb4f0935/pbr-6.1.1.tar.gz", hash = "sha256:93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b", size = 125702, upload-time = "2025-02-04T14:28:06.514Z" }
 wheels = [
@@ -1193,24 +683,8 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
-]
-
-[[package]]
-name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
@@ -1218,24 +692,8 @@ wheels = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
-]
-
-[[package]]
-name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -1255,8 +713,7 @@ name = "pymdown-extensions"
 version = "10.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown", version = "3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "markdown", version = "3.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "markdown" },
     { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/92/a7296491dbf5585b3a987f3f3fc87af0e632121ff3e490c14b5f2d2b4eb5/pymdown_extensions-10.15.tar.gz", hash = "sha256:0e5994e32155f4b03504f939e501b981d306daf7ec2aa1cd2eb6bd300784f8f7", size = 852320, upload-time = "2025-04-27T23:48:29.183Z" }
@@ -1273,8 +730,7 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
-    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pluggy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
@@ -1284,31 +740,11 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.9'" },
-    { name = "pytest", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
-]
-
-[[package]]
-name = "pytest-cov"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "coverage", version = "7.8.2", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.9'" },
-    { name = "pytest", marker = "python_full_version >= '3.9'" },
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
 wheels = [
@@ -1337,15 +773,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -1390,49 +817,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
-    { url = "https://files.pythonhosted.org/packages/74/d9/323a59d506f12f498c2097488d80d16f4cf965cee1791eab58b56b19f47a/PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a", size = 183218, upload-time = "2024-08-06T20:33:06.411Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cc/20c34d00f04d785f2028737e2e2a8254e1425102e730fee1d6396f832577/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5", size = 728067, upload-time = "2024-08-06T20:33:07.879Z" },
-    { url = "https://files.pythonhosted.org/packages/20/52/551c69ca1501d21c0de51ddafa8c23a0191ef296ff098e98358f69080577/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d", size = 757812, upload-time = "2024-08-06T20:33:12.542Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/7f/2c3697bba5d4aa5cc2afe81826d73dfae5f049458e44732c7a0938baa673/PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083", size = 746531, upload-time = "2024-08-06T20:33:14.391Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ab/6226d3df99900e580091bb44258fde77a8433511a86883bd4681ea19a858/PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706", size = 800820, upload-time = "2024-08-06T20:33:16.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/99/a9eb0f3e710c06c5d922026f6736e920d431812ace24aae38228d0d64b04/PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a", size = 145514, upload-time = "2024-08-06T20:33:22.414Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8a/ee831ad5fafa4431099aa4e078d4c8efd43cd5e48fbc774641d233b683a9/PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff", size = 162702, upload-time = "2024-08-06T20:33:23.813Z" },
-    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777, upload-time = "2024-08-06T20:33:25.896Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318, upload-time = "2024-08-06T20:33:27.212Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891, upload-time = "2024-08-06T20:33:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614, upload-time = "2024-08-06T20:33:34.157Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360, upload-time = "2024-08-06T20:33:35.84Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006, upload-time = "2024-08-06T20:33:37.501Z" },
-    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577, upload-time = "2024-08-06T20:33:39.389Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593, upload-time = "2024-08-06T20:33:46.63Z" },
-    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312, upload-time = "2024-08-06T20:33:49.073Z" },
-]
-
-[[package]]
-name = "pyyaml-env-tag"
-version = "0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "pyyaml", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/8e/da1c6c58f751b70f8ceb1eb25bc25d524e8f14fe16edcce3f4e3ba08629c/pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb", size = 5631, upload-time = "2020-11-12T02:38:26.239Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/66/bbb1dd374f5c870f59c5bb1db0e18cbe7fa739415a24cbd95b2d1f5ae0c4/pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069", size = 3911, upload-time = "2020-11-12T02:38:24.638Z" },
 ]
 
 [[package]]
 name = "pyyaml-env-tag"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "pyyaml", marker = "python_full_version >= '3.9'" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
@@ -1447,8 +839,7 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "idna" },
-    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
@@ -1496,24 +887,8 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.3.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/01/771ea46cce201dd42cff043a5eea929d1c030fb3d1c2ee2729d02ca7814c/setuptools-75.3.2.tar.gz", hash = "sha256:3c1383e1038b68556a382c1e8ded8887cd20141b0eb5708a6c8d277de49364f5", size = 1354489, upload-time = "2025-03-12T00:02:19.004Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/65/3f0dba35760d902849d39d38c0a72767794b1963227b69a587f8a336d08c/setuptools-75.3.2-py3-none-any.whl", hash = "sha256:90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9", size = 1251198, upload-time = "2025-03-12T00:02:17.554Z" },
-]
-
-[[package]]
-name = "setuptools"
 version = "80.8.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
@@ -1539,29 +914,10 @@ wheels = [
 
 [[package]]
 name = "stevedore"
-version = "5.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "pbr", marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/59/f8aefa21020054f553bf7e3b405caec7f8d1f432d9cb47e34aaa244d8d03/stevedore-5.3.0.tar.gz", hash = "sha256:9a64265f4060312828151c204efbe9b7a9852a0d9228756344dbc7e4023e375a", size = 513768, upload-time = "2024-08-22T13:45:52.001Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/50/70762bdb23f6c2b746b90661f461d33c4913a22a46bb5265b10947e85ffb/stevedore-5.3.0-py3-none-any.whl", hash = "sha256:1efd34ca08f474dad08d9b19e934a22c68bb6fe416926479ba29e5013bcc8f78", size = 49661, upload-time = "2024-08-22T13:45:50.804Z" },
-]
-
-[[package]]
-name = "stevedore"
 version = "5.4.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "pbr", marker = "python_full_version >= '3.9'" },
+    { name = "pbr" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/3f/13cacea96900bbd31bb05c6b74135f85d15564fc583802be56976c940470/stevedore-5.4.1.tar.gz", hash = "sha256:3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b", size = 513858, upload-time = "2025-02-20T14:03:57.285Z" }
 wheels = [
@@ -1618,24 +974,8 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
-]
-
-[[package]]
-name = "urllib3"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
@@ -1643,57 +983,8 @@ wheels = [
 
 [[package]]
 name = "watchdog"
-version = "4.0.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/38/764baaa25eb5e35c9a043d4c4588f9836edfe52a708950f4b6d5f714fd42/watchdog-4.0.2.tar.gz", hash = "sha256:b4dfbb6c49221be4535623ea4474a4d6ee0a9cef4a80b20c28db4d858b64e270", size = 126587, upload-time = "2024-08-11T07:38:01.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/b0/219893d41c16d74d0793363bf86df07d50357b81f64bba4cb94fe76e7af4/watchdog-4.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ede7f010f2239b97cc79e6cb3c249e72962404ae3865860855d5cbe708b0fd22", size = 100257, upload-time = "2024-08-11T07:37:04.209Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c6/8e90c65693e87d98310b2e1e5fd7e313266990853b489e85ce8396cc26e3/watchdog-4.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a2cffa171445b0efa0726c561eca9a27d00a1f2b83846dbd5a4f639c4f8ca8e1", size = 92249, upload-time = "2024-08-11T07:37:06.364Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/cd/2e306756364a934532ff8388d90eb2dc8bb21fe575cd2b33d791ce05a02f/watchdog-4.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c50f148b31b03fbadd6d0b5980e38b558046b127dc483e5e4505fcef250f9503", size = 92888, upload-time = "2024-08-11T07:37:08.275Z" },
-    { url = "https://files.pythonhosted.org/packages/de/78/027ad372d62f97642349a16015394a7680530460b1c70c368c506cb60c09/watchdog-4.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7c7d4bf585ad501c5f6c980e7be9c4f15604c7cc150e942d82083b31a7548930", size = 100256, upload-time = "2024-08-11T07:37:11.017Z" },
-    { url = "https://files.pythonhosted.org/packages/59/a9/412b808568c1814d693b4ff1cec0055dc791780b9dc947807978fab86bc1/watchdog-4.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:914285126ad0b6eb2258bbbcb7b288d9dfd655ae88fa28945be05a7b475a800b", size = 92252, upload-time = "2024-08-11T07:37:13.098Z" },
-    { url = "https://files.pythonhosted.org/packages/04/57/179d76076cff264982bc335dd4c7da6d636bd3e9860bbc896a665c3447b6/watchdog-4.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:984306dc4720da5498b16fc037b36ac443816125a3705dfde4fd90652d8028ef", size = 92888, upload-time = "2024-08-11T07:37:15.077Z" },
-    { url = "https://files.pythonhosted.org/packages/92/f5/ea22b095340545faea37ad9a42353b265ca751f543da3fb43f5d00cdcd21/watchdog-4.0.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1cdcfd8142f604630deef34722d695fb455d04ab7cfe9963055df1fc69e6727a", size = 100342, upload-time = "2024-08-11T07:37:16.393Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d2/8ce97dff5e465db1222951434e3115189ae54a9863aef99c6987890cc9ef/watchdog-4.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d7ab624ff2f663f98cd03c8b7eedc09375a911794dfea6bf2a359fcc266bff29", size = 92306, upload-time = "2024-08-11T07:37:17.997Z" },
-    { url = "https://files.pythonhosted.org/packages/49/c4/1aeba2c31b25f79b03b15918155bc8c0b08101054fc727900f1a577d0d54/watchdog-4.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:132937547a716027bd5714383dfc40dc66c26769f1ce8a72a859d6a48f371f3a", size = 92915, upload-time = "2024-08-11T07:37:19.967Z" },
-    { url = "https://files.pythonhosted.org/packages/79/63/eb8994a182672c042d85a33507475c50c2ee930577524dd97aea05251527/watchdog-4.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd67c7df93eb58f360c43802acc945fa8da70c675b6fa37a241e17ca698ca49b", size = 100343, upload-time = "2024-08-11T07:37:21.935Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/82/027c0c65c2245769580605bcd20a1dc7dfd6c6683c8c4e2ef43920e38d27/watchdog-4.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bcfd02377be80ef3b6bc4ce481ef3959640458d6feaae0bd43dd90a43da90a7d", size = 92313, upload-time = "2024-08-11T07:37:23.314Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/89/ad4715cbbd3440cb0d336b78970aba243a33a24b1a79d66f8d16b4590d6a/watchdog-4.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:980b71510f59c884d684b3663d46e7a14b457c9611c481e5cef08f4dd022eed7", size = 92919, upload-time = "2024-08-11T07:37:24.715Z" },
-    { url = "https://files.pythonhosted.org/packages/55/08/1a9086a3380e8828f65b0c835b86baf29ebb85e5e94a2811a2eb4f889cfd/watchdog-4.0.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:aa160781cafff2719b663c8a506156e9289d111d80f3387cf3af49cedee1f040", size = 100255, upload-time = "2024-08-11T07:37:26.862Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/3e/064974628cf305831f3f78264800bd03b3358ec181e3e9380a36ff156b93/watchdog-4.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f6ee8dedd255087bc7fe82adf046f0b75479b989185fb0bdf9a98b612170eac7", size = 92257, upload-time = "2024-08-11T07:37:28.253Z" },
-    { url = "https://files.pythonhosted.org/packages/23/69/1d2ad9c12d93bc1e445baa40db46bc74757f3ffc3a3be592ba8dbc51b6e5/watchdog-4.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0b4359067d30d5b864e09c8597b112fe0a0a59321a0f331498b013fb097406b4", size = 92886, upload-time = "2024-08-11T07:37:29.52Z" },
-    { url = "https://files.pythonhosted.org/packages/68/eb/34d3173eceab490d4d1815ba9a821e10abe1da7a7264a224e30689b1450c/watchdog-4.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:770eef5372f146997638d737c9a3c597a3b41037cfbc5c41538fc27c09c3a3f9", size = 100254, upload-time = "2024-08-11T07:37:30.888Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a1/4bbafe7ace414904c2cc9bd93e472133e8ec11eab0b4625017f0e34caad8/watchdog-4.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eeea812f38536a0aa859972d50c76e37f4456474b02bd93674d1947cf1e39578", size = 92249, upload-time = "2024-08-11T07:37:32.193Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/11/ec5684e0ca692950826af0de862e5db167523c30c9cbf9b3f4ce7ec9cc05/watchdog-4.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b2c45f6e1e57ebb4687690c05bc3a2c1fb6ab260550c4290b8abb1335e0fd08b", size = 92891, upload-time = "2024-08-11T07:37:34.212Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/9a/6f30f023324de7bad8a3eb02b0afb06bd0726003a3550e9964321315df5a/watchdog-4.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:10b6683df70d340ac3279eff0b2766813f00f35a1d37515d2c99959ada8f05fa", size = 91775, upload-time = "2024-08-11T07:37:35.567Z" },
-    { url = "https://files.pythonhosted.org/packages/87/62/8be55e605d378a154037b9ba484e00a5478e627b69c53d0f63e3ef413ba6/watchdog-4.0.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:f7c739888c20f99824f7aa9d31ac8a97353e22d0c0e54703a547a218f6637eb3", size = 92255, upload-time = "2024-08-11T07:37:37.596Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/59/12e03e675d28f450bade6da6bc79ad6616080b317c472b9ae688d2495a03/watchdog-4.0.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c100d09ac72a8a08ddbf0629ddfa0b8ee41740f9051429baa8e31bb903ad7508", size = 91682, upload-time = "2024-08-11T07:37:38.901Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/69/241998de9b8e024f5c2fbdf4324ea628b4231925305011ca8b7e1c3329f6/watchdog-4.0.2-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:f5315a8c8dd6dd9425b974515081fc0aadca1d1d61e078d2246509fd756141ee", size = 92249, upload-time = "2024-08-11T07:37:40.143Z" },
-    { url = "https://files.pythonhosted.org/packages/70/3f/2173b4d9581bc9b5df4d7f2041b6c58b5e5448407856f68d4be9981000d0/watchdog-4.0.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2d468028a77b42cc685ed694a7a550a8d1771bb05193ba7b24006b8241a571a1", size = 91773, upload-time = "2024-08-11T07:37:42.095Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/de/6fff29161d5789048f06ef24d94d3ddcc25795f347202b7ea503c3356acb/watchdog-4.0.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f15edcae3830ff20e55d1f4e743e92970c847bcddc8b7509bcd172aa04de506e", size = 92250, upload-time = "2024-08-11T07:37:44.052Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/b1/25acf6767af6f7e44e0086309825bd8c098e301eed5868dc5350642124b9/watchdog-4.0.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:936acba76d636f70db8f3c66e76aa6cb5136a936fc2a5088b9ce1c7a3508fc83", size = 82947, upload-time = "2024-08-11T07:37:45.388Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/90/aebac95d6f954bd4901f5d46dcd83d68e682bfd21798fd125a95ae1c9dbf/watchdog-4.0.2-py3-none-manylinux2014_armv7l.whl", hash = "sha256:e252f8ca942a870f38cf785aef420285431311652d871409a64e2a0a52a2174c", size = 82942, upload-time = "2024-08-11T07:37:46.722Z" },
-    { url = "https://files.pythonhosted.org/packages/15/3a/a4bd8f3b9381824995787488b9282aff1ed4667e1110f31a87b871ea851c/watchdog-4.0.2-py3-none-manylinux2014_i686.whl", hash = "sha256:0e83619a2d5d436a7e58a1aea957a3c1ccbf9782c43c0b4fed80580e5e4acd1a", size = 82947, upload-time = "2024-08-11T07:37:48.941Z" },
-    { url = "https://files.pythonhosted.org/packages/09/cc/238998fc08e292a4a18a852ed8274159019ee7a66be14441325bcd811dfd/watchdog-4.0.2-py3-none-manylinux2014_ppc64.whl", hash = "sha256:88456d65f207b39f1981bf772e473799fcdc10801062c36fd5ad9f9d1d463a73", size = 82946, upload-time = "2024-08-11T07:37:50.279Z" },
-    { url = "https://files.pythonhosted.org/packages/80/f1/d4b915160c9d677174aa5fae4537ae1f5acb23b3745ab0873071ef671f0a/watchdog-4.0.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:32be97f3b75693a93c683787a87a0dc8db98bb84701539954eef991fb35f5fbc", size = 82947, upload-time = "2024-08-11T07:37:51.55Z" },
-    { url = "https://files.pythonhosted.org/packages/db/02/56ebe2cf33b352fe3309588eb03f020d4d1c061563d9858a9216ba004259/watchdog-4.0.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:c82253cfc9be68e3e49282831afad2c1f6593af80c0daf1287f6a92657986757", size = 82944, upload-time = "2024-08-11T07:37:52.855Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d2/c8931ff840a7e5bd5dcb93f2bb2a1fd18faf8312e9f7f53ff1cf76ecc8ed/watchdog-4.0.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c0b14488bd336c5b1845cee83d3e631a1f8b4e9c5091ec539406e4a324f882d8", size = 82947, upload-time = "2024-08-11T07:37:55.172Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d8/cdb0c21a4a988669d7c210c75c6a2c9a0e16a3b08d9f7e633df0d9a16ad8/watchdog-4.0.2-py3-none-win32.whl", hash = "sha256:0d8a7e523ef03757a5aa29f591437d64d0d894635f8a50f370fe37f913ce4e19", size = 82935, upload-time = "2024-08-11T07:37:56.668Z" },
-    { url = "https://files.pythonhosted.org/packages/99/2e/b69dfaae7a83ea64ce36538cc103a3065e12c447963797793d5c0a1d5130/watchdog-4.0.2-py3-none-win_amd64.whl", hash = "sha256:c344453ef3bf875a535b0488e3ad28e341adbd5a9ffb0f7d62cefacc8824ef2b", size = 82934, upload-time = "2024-08-11T07:37:57.991Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/0b/43b96a9ecdd65ff5545b1b13b687ca486da5c6249475b1a45f24d63a1858/watchdog-4.0.2-py3-none-win_ia64.whl", hash = "sha256:baececaa8edff42cd16558a639a9b0ddf425f93d892e8392a56bf904f5eff22c", size = 82933, upload-time = "2024-08-11T07:37:59.573Z" },
-]
-
-[[package]]
-name = "watchdog"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
@@ -1708,13 +999,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
     { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
     { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
-    { url = "https://files.pythonhosted.org/packages/05/52/7223011bb760fce8ddc53416beb65b83a3ea6d7d13738dde75eeb2c89679/watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8", size = 96390, upload-time = "2024-11-01T14:06:49.325Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/62/d2b21bc4e706d3a9d467561f487c2938cbd881c69f3808c43ac1ec242391/watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a", size = 88386, upload-time = "2024-11-01T14:06:50.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/22/1c90b20eda9f4132e4603a26296108728a8bfe9584b006bd05dd94548853/watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c", size = 89017, upload-time = "2024-11-01T14:06:51.717Z" },
     { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/79/69f2b0e8d3f2afd462029031baafb1b75d11bb62703f0e1022b2e54d49ee/watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa", size = 87903, upload-time = "2024-11-01T14:06:57.052Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/2b/dc048dd71c2e5f0f7ebc04dd7912981ec45793a03c0dc462438e0591ba5d/watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e", size = 88381, upload-time = "2024-11-01T14:06:58.193Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
     { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
     { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
@@ -1725,37 +1011,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
-]
-
-[[package]]
-name = "wheel"
-version = "0.45.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729", size = 107545, upload-time = "2024-11-23T00:18:23.513Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248", size = 72494, upload-time = "2024-11-23T00:18:21.207Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.20.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199, upload-time = "2024-09-13T13:44:16.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200, upload-time = "2024-09-13T13:44:14.38Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.21.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.9.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545, upload-time = "2024-11-10T15:05:20.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630, upload-time = "2024-11-10T15:05:19.275Z" },
 ]


### PR DESCRIPTION
## Description
Modernize CertMonitor onto a **Python 3.10+ baseline** for the 0.5.0 line: drop the end-of-life Python 3.8/3.9, add Python 3.14 and 3.15 (pre-release) support, and sweep the codebase to 3.10+ idioms. No runtime behavior change for supported interpreters.

## Type of Change
- [x] 💥 Breaking change (drops Python 3.8 and 3.9 support)
- [x] 🔨 Build/CI improvements
- [x] 🔧 Code refactoring (no functional changes)
- [x] 📚 Documentation update

## Related Issues
Fixes #61

## Changes Made
- **Python support:** `requires-python = ">=3.10,<3.16"`; classifiers drop 3.8/3.9 and add 3.14. Added 3.14 + 3.15 (pre-release via `allow-prereleases`) to the CI matrix.
- **Rust:** raised the pyo3 abi3 floor to `abi3-py310` to match the new minimum.
- **Modernization:** built-in generics (`list`/`dict`), `X | None` unions, full ruff `pyupgrade` (UP) sweep, with `target-version = "py310"` enforcing it going forward.
- **Dead code:** removed the unreachable 3.8/3.9 chain-retrieval fallbacks and refreshed stale version comments; chain validators now rely on stdlib chain APIs unconditionally.
- **Docs:** updated all Python version references to 3.10-3.15.
- **CI actions:** checkout v6, setup-python v6, setup-uv v8, codecov v5 (+ token upload), action-gh-release v2.
- **Fix:** README logo now uses an absolute CDN URL so it renders on the PyPI project page.

## Testing
- [x] All existing tests pass
- [x] New tests added for new functionality (updated the chain-unavailable test for the 3.10+ baseline)
- [x] Tested manually with the following scenarios:
  - [x] Basic certificate validation
  - [x] Custom validators (if applicable)
  - [x] Error handling
  - [x] Protocol detection (if applicable)

### Test Commands Run
```bash
uv run pytest            # 536 passed
uv run ruff format --check . && uv run ruff check .   # clean
uv run mypy certmonitor/ --ignore-missing-imports     # clean
cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings   # clean
cargo test --no-default-features   # 92 passed
```

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [x] I have considered the security implications of this change
- [x] Security review is not needed / Security review has been completed

## Documentation
- [x] Code comments updated
- [x] README.md updated (if needed)
- [x] API documentation updated (if needed)
- [x] Usage examples updated (if needed)
- [x] Changelog updated (if applicable)

## Breaking Changes
This PR drops support for **Python 3.8 and 3.9** (both end-of-life). The minimum supported version is now Python 3.10. Users on 3.8/3.9 should pin to `certmonitor<0.5` or upgrade their interpreter.

## Additional Notes
The version stays at `0.4.0` on this branch by design. The bump to `0.5.0` happens at release-cut time (`make version.minor` + the release workflow), not in this feature PR. The 0.5.0 entries are staged under `[Unreleased]` in CHANGELOG.md.

---

### For Maintainers
- [x] Version bump needed (0.5.0, at release-cut)
- [x] Release notes updated (CHANGELOG `[Unreleased]`)
- [x] Migration guide needed (for breaking changes) — noted in Breaking Changes above
